### PR TITLE
add k8s cluster dns var in cluster-desc.yaml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ cd /go/src/github.com/docker/distribution && \
 make PREFIX=/go clean binaries && \
 mkdir -p /etc/docker/registry && \
 cp /go/src/github.com/docker/distribution/cmd/registry/config-dev.yml /etc/docker/registry/config.yml && \
-go get github.com/k8sp/auto-install/cloud-config-server && \
+go get github.com/k8sp/sextant/cloud-config-server && \
 mkdir /go/static
 
 # NOTICE: change install.sh HTTP server ip:port when running start.sh

--- a/bootstrapper/coreos/coreos.go
+++ b/bootstrapper/coreos/coreos.go
@@ -5,8 +5,8 @@ import (
 	"os"
 	"path"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 	"github.com/wangkuiyi/sh"
 )

--- a/bootstrapper/coreos/coreos_test.go
+++ b/bootstrapper/coreos/coreos_test.go
@@ -1,7 +1,6 @@
 package coreos
 
 import (
-	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -9,20 +8,8 @@ import (
 	"github.com/k8sp/sextant/bootstrapper/cmd"
 	"github.com/k8sp/sextant/bootstrapper/vmtest"
 	"github.com/k8sp/sextant/config"
-	"github.com/stretchr/testify/assert"
 	"github.com/topicai/candy"
 )
-
-func TestVersion(t *testing.T) {
-	channel, _ := version("")
-	assert.Equal(t, "stable", channel)
-
-	_, alpha := version("alpha")
-	_, beta := version("beta")
-	_, stable := version("stable")
-	assert.True(t, strings.Compare(stable, beta) <= 0)
-	assert.True(t, strings.Compare(stable, alpha) <= 0)
-}
 
 func TestDownloadBootImage(t *testing.T) {
 	if *vmtest.InVM {

--- a/bootstrapper/coreos/coreos_test.go
+++ b/bootstrapper/coreos/coreos_test.go
@@ -6,9 +6,9 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/bootstrapper/vmtest"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/bootstrapper/vmtest"
+	"github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/topicai/candy"
 )

--- a/bootstrapper/dhcp/dhcp.go
+++ b/bootstrapper/dhcp/dhcp.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"log"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/bootstrapper/dhcp/dhcp_conf.go
+++ b/bootstrapper/dhcp/dhcp_conf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"html/template"
 
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/bootstrapper/dhcp/dhcp_conf_test.go
+++ b/bootstrapper/dhcp/dhcp_conf_test.go
@@ -3,7 +3,7 @@ package dhcp
 import (
 	"testing"
 
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/topicai/candy"
 	"gopkg.in/yaml.v2"

--- a/bootstrapper/dhcp/dhcp_test.go
+++ b/bootstrapper/dhcp/dhcp_test.go
@@ -9,8 +9,8 @@ import (
 
 	"log"
 
-	"github.com/k8sp/auto-install/bootstrapper/vmtest"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/vmtest"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 	"github.com/wangkuiyi/sh"
 )

--- a/bootstrapper/nginx/nginx.go
+++ b/bootstrapper/nginx/nginx.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"log"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/bootstrapper/nginx/nginx_conf.go
+++ b/bootstrapper/nginx/nginx_conf.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"html/template"
 
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/bootstrapper/nginx/nginx_conf_test.go
+++ b/bootstrapper/nginx/nginx_conf_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/topicai/candy"
 	"gopkg.in/yaml.v2"
 
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/bootstrapper/nginx/nginx_test.go
+++ b/bootstrapper/nginx/nginx_test.go
@@ -6,8 +6,8 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/k8sp/auto-install/bootstrapper/vmtest"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/vmtest"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 	"github.com/wangkuiyi/sh"
 )

--- a/bootstrapper/skydns/skydns.go
+++ b/bootstrapper/skydns/skydns.go
@@ -8,8 +8,8 @@ import (
 	"log"
 	"runtime"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/bootstrapper/skydns/skydns_test.go
+++ b/bootstrapper/skydns/skydns_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/wangkuiyi/sh"
 	"gopkg.in/yaml.v2"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
-	"github.com/k8sp/auto-install/bootstrapper/vmtest"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
+	"github.com/k8sp/sextant/bootstrapper/vmtest"
+	"github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/cloud-config-server/README.md
+++ b/cloud-config-server/README.md
@@ -82,11 +82,11 @@ export GOPATH=<GoPathDir>
 
 ## 获取并编译Go代码
 
-下面的命令中需要使用到[Github personal access token](https://github.com/k8sp/auto-install/issues/29)，请根据[这篇文档](https://github.com/k8sp/auto-install/issues/29)事先生成。
+下面的命令中需要使用到[Github personal access token](https://github.com/k8sp/sextant/issues/29)，请根据[这篇文档](https://github.com/k8sp/sextant/issues/29)事先生成。
 
 ```
 git config --global url."https://<GitHubPersonalAccessToken>:x-oauth-basic@github.com/".insteadOf "https://github.com/" 
-go get github.com/k8sp/auto-install/cloud-config-server
+go get github.com/k8sp/sextant/cloud-config-server
 
 ```
 

--- a/cloud-config-server/certgen/certgen.go
+++ b/cloud-config-server/certgen/certgen.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/k8sp/auto-install/bootstrapper/cmd"
+	"github.com/k8sp/sextant/bootstrapper/cmd"
 	"github.com/topicai/candy"
 )
 

--- a/cloud-config-server/server.go
+++ b/cloud-config-server/server.go
@@ -22,22 +22,22 @@ import (
 	"text/template"
 
 	"github.com/gorilla/mux"
-	"github.com/k8sp/auto-install/cloud-config-server/cache"
-	"github.com/k8sp/auto-install/cloud-config-server/certgen"
-	cctemplate "github.com/k8sp/auto-install/cloud-config-server/template"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/cloud-config-server/cache"
+	"github.com/k8sp/sextant/cloud-config-server/certgen"
+	cctemplate "github.com/k8sp/sextant/cloud-config-server/template"
+	"github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 	"gopkg.in/yaml.v2"
 )
 
 func main() {
 	clusterDescURL := flag.String("cluster-desc-url",
-		"https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/unisound-ailab/build_config.yml",
+		"https://raw.githubusercontent.com/k8sp/sextant/master/cloud-config-server/template/unisound-ailab/build_config.yml",
 		"URL to remote cluster description YAML file.")
 	clusterDescFile := flag.String("cluster-desc-file", "./cluster-desc.yml", "Local copy of cluster description YAML file.")
 
 	ccTemplateURL := flag.String("cc-template-url",
-		"https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/cloud-config.template",
+		"https://raw.githubusercontent.com/k8sp/sextant/master/cloud-config-server/template/cloud-config.template",
 		"URL to cloud-config file template.")
 	ccTemplateFile := flag.String("cc-template-file", "./cloud-config.template", "Local copy of cloud-config file template.")
 

--- a/cloud-config-server/server_test.go
+++ b/cloud-config-server/server_test.go
@@ -12,14 +12,14 @@ import (
 
 	"gopkg.in/yaml.v2"
 
-	"github.com/k8sp/auto-install/cloud-config-server/certgen"
-	"github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/cloud-config-server/certgen"
+	"github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/topicai/candy"
 )
 
 const (
-	tmplFile    = "src/github.com/k8sp/auto-install/cloud-config-server/template/cloud-config.template"
+	tmplFile    = "src/github.com/k8sp/sextant/cloud-config-server/template/cloud-config.template"
 	loadTimeout = 15 * time.Second
 )
 

--- a/cloud-config-server/template/cloud-config.template
+++ b/cloud-config-server/template/cloud-config.template
@@ -71,7 +71,7 @@ write_files:
               - --insecure-bind-address=0.0.0.0
               - --secure-port=443
               - --etcd-servers=http://{{ .MasterHostname }}:4001
-              - --service-cluster-ip-range=10.100.0.0/24
+              - --service-cluster-ip-range={{ .K8sServiceClusterIPRange }} 
               - --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
               - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
               - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem

--- a/cloud-config-server/template/cloud-config.template
+++ b/cloud-config-server/template/cloud-config.template
@@ -356,7 +356,7 @@ coreos:
             --allow-privileged=true \
             --config=/etc/kubernetes/manifests \
             --hostname-override={{ .MasterHostname }} \
-            --cluster-dns=10.100.0.10 \
+            --cluster-dns={{ .K8sClusterDNS }} \
             --cluster-domain=cluster.local
             --logtostderr=true
             Restart=always
@@ -382,7 +382,7 @@ coreos:
             --pod_infra_container_image={{ .Dockerdomain }}:5000/pause:2.0 \
             --address=0.0.0.0 \
             --allow-privileged=true \
-            --cluster-dns=10.100.0.10 \
+            --cluster-dns={{ .K8sClusterDNS }} \
             --cluster-domain=cluster.local \
             --config=/etc/kubernetes/manifests \
             --hostname-override=${DEFAULT_IPV4} \

--- a/cloud-config-server/template/template.go
+++ b/cloud-config-server/template/template.go
@@ -13,21 +13,23 @@ import (
 
 // ExecutionConfig struct config a Coreos's cloud config file which use for installing Coreos in k8s cluster.
 type ExecutionConfig struct {
-	Hostname          string
-	IP                string
-	CephMonitor       bool
-	KubeMaster        bool
-	EtcdMember        bool
-	InitialCluster    string
-	SSHAuthorizedKeys string
-	EtcdEndpoints     string
-	MasterIP          string
-	MasterHostname    string
-	BootstrapperIP    string
-	CaCrt             string
-	Crt               string
-	Key               string
-	Dockerdomain      string
+	Hostname                 string
+	IP                       string
+	CephMonitor              bool
+	KubeMaster               bool
+	EtcdMember               bool
+	InitialCluster           string
+	SSHAuthorizedKeys        string
+	EtcdEndpoints            string
+	MasterIP                 string
+	MasterHostname           string
+	BootstrapperIP           string
+	CaCrt                    string
+	Crt                      string
+	Key                      string
+	Dockerdomain             string
+	K8sClusterDNS            string
+	K8sServiceClusterIPRange string
 }
 
 // Execute returns the executed cloud-config template for a node with
@@ -43,16 +45,18 @@ func Execute(tmpl *template.Template, config *tpcfg.Cluster, mac, caKey, caCrt s
 	}
 
 	ec := ExecutionConfig{
-		Hostname:          node.Hostname(),
-		CephMonitor:       node.CephMonitor,
-		KubeMaster:        node.KubeMaster,
-		EtcdMember:        node.EtcdMember,
-		InitialCluster:    config.InitialEtcdCluster(),
-		SSHAuthorizedKeys: config.SSHAuthorizedKeys,
-		MasterHostname:    config.GetMasterHostname(),
-		EtcdEndpoints:     config.GetEtcdEndpoints(),
-		BootstrapperIP:    config.Bootstrapper,
-		Dockerdomain:      config.Dockerdomain,
+		Hostname:                 node.Hostname(),
+		CephMonitor:              node.CephMonitor,
+		KubeMaster:               node.KubeMaster,
+		EtcdMember:               node.EtcdMember,
+		InitialCluster:           config.InitialEtcdCluster(),
+		SSHAuthorizedKeys:        config.SSHAuthorizedKeys,
+		MasterHostname:           config.GetMasterHostname(),
+		EtcdEndpoints:            config.GetEtcdEndpoints(),
+		BootstrapperIP:           config.Bootstrapper,
+		Dockerdomain:             config.Dockerdomain,
+		K8sClusterDNS:            config.K8sClusterDNS,
+		K8sServiceClusterIPRange: config.K8sServiceClusterIPRange,
 		// Mulit-line context in yaml should keep the indent,
 		// there is no good idea for templaet package to auto keep the indent so far,
 		// so insert 6*whitespace at the begging of every line

--- a/cloud-config-server/template/template.go
+++ b/cloud-config-server/template/template.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/k8sp/auto-install/cloud-config-server/certgen"
-	tpcfg "github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/cloud-config-server/certgen"
+	tpcfg "github.com/k8sp/sextant/config"
 	"github.com/topicai/candy"
 )
 

--- a/cloud-config-server/template/template_test.go
+++ b/cloud-config-server/template/template_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"text/template"
 
-	"github.com/k8sp/auto-install/cloud-config-server/certgen"
-	tpcfg "github.com/k8sp/auto-install/config"
+	"github.com/k8sp/sextant/cloud-config-server/certgen"
+	tpcfg "github.com/k8sp/sextant/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/topicai/candy"
 	"gopkg.in/yaml.v2"

--- a/cloud-config-server/template/unisound-ailab/build_config.yml
+++ b/cloud-config-server/template/unisound-ailab/build_config.yml
@@ -8,6 +8,7 @@ broadcast: 10.10.10.255
 nameservers: [10.10.10.192, 8.8.8.8, 8.8.4.4]
 domainname: "ailab.unisound.com"
 dockerdomain: "bootstrapper"
+k8s_service_cluster_ip_range: 10.100.0.0/24
 k8s_cluster_dns: 10.100.0.10
 
 nodes:

--- a/cloud-config-server/template/unisound-ailab/build_config.yml
+++ b/cloud-config-server/template/unisound-ailab/build_config.yml
@@ -8,6 +8,7 @@ broadcast: 10.10.10.255
 nameservers: [10.10.10.192, 8.8.8.8, 8.8.4.4]
 domainname: "ailab.unisound.com"
 dockerdomain: "bootstrapper"
+k8s_cluster_dns: 10.100.0.10
 
 nodes:
   - mac: "00:25:90:c0:f7:80"

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,7 @@ type Cluster struct {
 
 	SSHAuthorizedKeys string `yaml:"ssh_authorized_keys"` // So maintainers can SSH to all nodes.
 	Dockerdomain      string
+	K8sClusterDNS     string `yaml:"k8s_cluster_dns"`
 }
 
 // Node defines properties of some nodes in the cluster.  For example,

--- a/config/config.go
+++ b/config/config.go
@@ -11,7 +11,7 @@ type Cluster struct {
 	// Bootstrapper is the IP of the PXE server (DHCP + TFTP,
 	// https://github.com/k8sp/bare-metal-coreos), which is also
 	// an Ngix server and SkyDNS server
-	// (https://github.com/k8sp/auto-install/tree/master/dns).
+	// (https://github.com/k8sp/sextant/tree/master/dns).
 	Bootstrapper string
 
 	// The following are for configuring the DHCP service on the
@@ -75,7 +75,7 @@ func (n Node) Mac() string {
 // It is also used for unit testing.  The IP addresses and subnet used
 // in this example are in accordance with Vagrant VM's default subnet,
 // so unit tests on DHCP can starts DHCP services correctly
-// (c.f. https://github.com/k8sp/auto-install/issues/52).
+// (c.f. https://github.com/k8sp/sextant/issues/52).
 const ExampleYAML = `
 bootstrapper: 10.0.2.15
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,10 @@ type Cluster struct {
 
 	NginxRootDir string `yaml:"nginx_root_dir"`
 
-	SSHAuthorizedKeys string `yaml:"ssh_authorized_keys"` // So maintainers can SSH to all nodes.
-	Dockerdomain      string
-	K8sClusterDNS     string `yaml:"k8s_cluster_dns"`
+	SSHAuthorizedKeys        string `yaml:"ssh_authorized_keys"` // So maintainers can SSH to all nodes.
+	Dockerdomain             string
+	K8sClusterDNS            string `yaml:"k8s_cluster_dns"`
+	K8sServiceClusterIPRange string `yaml:"k8s_service_cluster_ip_range"`
 }
 
 // Node defines properties of some nodes in the cluster.  For example,

--- a/doc/bootstrapper.md
+++ b/doc/bootstrapper.md
@@ -28,7 +28,7 @@ docker run -d [bootstrapper_image_name:tag] -v /path/to/ClusterDesc.yaml:/path/t
 
 ***详细流程描述***
 
-1. 规划机群，并且把规划描述成[ClusterDesc配置文件](https://raw.githubusercontent.com/k8sp/auto-install/master/cloud-config-server/template/unisound-ailab/build_config.yml)，比如如哪个机器作为master，哪些机器作为etcd机群，哪些作为worker。每台机器通过MAC地址唯一标识。
+1. 规划机群，并且把规划描述成[ClusterDesc配置文件](https://raw.githubusercontent.com/k8sp/sextant/master/cloud-config-server/template/unisound-ailab/build_config.yml)，比如如哪个机器作为master，哪些机器作为etcd机群，哪些作为worker。每台机器通过MAC地址唯一标识。
 1. 管理员在一台预先规划好的的机器上，下载／上传bootstrapper的docker image，并通过docker run启动bootstrapper。启动成功后，bootstrapper会提供DHCP, DNS(服务于物理节点), PXE, tftp, cloud-config HTTP服务, CoreOS镜像自动更新服务。
 1. 将机群中的其他所有节点开机，并从网络引导安装。即可完成整个机群的初始化。
 1. 每启动一台新的机器（网络引导），先从DHCP获取一个IP地址，DHCP server将启动引导指向PXE server，然后由PXE server提供启动镜像（保存在tftpserver），至此，新的机器可以完成内存中的CoreOS引导，为CoreOS操作系统安装提供环境。
@@ -49,7 +49,7 @@ bootstrapper main读取ClusterDesc配置文件，并生成dnsmasq的配置文件
 完成配置后，bootstrapper main会分别启动dnsmasq, cloud-config-server, docker registry, CoreOS镜像自动更新程序（可选）。
 
 ### dnsmasq
-dnsmasq在机群中提供DHCP, DNS(物理机的DNS), PXE服务。使用docker启动dnsmasq的试验方法可以参考：https://github.com/k8sp/auto-install/issues/102
+dnsmasq在机群中提供DHCP, DNS(物理机的DNS), PXE服务。使用docker启动dnsmasq的试验方法可以参考：https://github.com/k8sp/sextant/issues/102
 
 ### cloud-config-server
 cloud-config-server是使用Go语言开发的一个HTTP Server，将提供安装kubernetes组件用到的需要通过HTTP访问的所有资源。包括：


### PR DESCRIPTION
fix #159 

1. 将cluster-dns变量统一放在cluster-desc中进行配置
1. 将原有package名为auto-install的地方都修改为sextant
1. 由于coreos版本stable和alpha版本号没有稳定的逻辑关系，去掉了coreos模块中关于version的测试