### PR TITLE
flannel always on early-docker

### DIFF
--- a/cloud-config-server/template/cloud-config.template
+++ b/cloud-config-server/template/cloud-config.template
@@ -21,7 +21,7 @@ write_files:
     permissions: 0600
     content: |
       {{ .Key }}
-  - path: /etc/flannel/options.env
+  - path: /run/flannel/options.env
     owner: root
     permissions: 0600
     content: |
@@ -71,7 +71,7 @@ write_files:
               - --insecure-bind-address=0.0.0.0
               - --secure-port=443
               - --etcd-servers=http://{{ .MasterHostname }}:4001
-              - --service-cluster-ip-range={{ .K8sServiceClusterIPRange }} 
+              - --service-cluster-ip-range={{ .K8sServiceClusterIPRange }}
               - --admission-control=NamespaceLifecycle,NamespaceExists,LimitRanger,SecurityContextDeny,ServiceAccount,ResourceQuota
               - --service-account-key-file=/etc/kubernetes/ssl/apiserver-key.pem
               - --tls-private-key-file=/etc/kubernetes/ssl/apiserver-key.pem
@@ -267,14 +267,53 @@ coreos:
               Environment=DOCKER_OPTS="--insecure-registry={{ .Dockerdomain }}:5000"
         - name: "flanneld.service"
           command: "start"
-          drop-ins:
-            - name: 50-network-config.conf
-              content: |
-                [Service]
-                Environment="FLANNEL_IMG={{ .Dockerdomain }}:5000/flannel"
-                {{- if .KubeMaster }}
-                ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
-                {{ end }}
+          content: |
+            [Unit]
+            Description=Network fabric for containers
+            Documentation=https://github.com/coreos/flannel
+            Requires=early-docker.service
+            After=etcd.service etcd2.service early-docker.service
+            Before=early-docker.target
+
+            [Service]
+            Type=notify
+            Restart=always
+            RestartSec=5
+            Environment="TMPDIR=/var/tmp/"
+            Environment="DOCKER_HOST=unix:///var/run/early-docker.sock"
+            Environment="FLANNEL_VER=0.5.5"
+            Environment="FLANNEL_IMG={{ .Dockerdomain }}:5000/flannel"
+            Environment="ETCD_SSL_DIR=/etc/ssl/etcd"
+            Environment="FLANNEL_ENV_FILE=/run/flannel/options.env"
+            LimitNOFILE=40000
+            LimitNPROC=1048576
+            ExecStartPre=/sbin/modprobe ip_tables
+            ExecStartPre=/usr/bin/mkdir -p /run/flannel
+            ExecStartPre=/usr/bin/mkdir -p ${ETCD_SSL_DIR}
+            ExecStartPre=-/usr/bin/touch ${FLANNEL_ENV_FILE}
+            {{- if .KubeMaster }}
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
+            {{ end }}
+
+            ExecStart=/usr/libexec/sdnotify-proxy /run/flannel/sd.sock \
+              /usr/bin/docker run --net=host --privileged=true --rm \
+              --volume=/run/flannel:/run/flannel \
+              --env=NOTIFY_SOCKET=/run/flannel/sd.sock \
+              --env=AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID} \
+              --env=AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY} \
+              --env-file=${FLANNEL_ENV_FILE} \
+              --volume=/usr/share/ca-certificates:/etc/ssl/certs:ro \
+              --volume=${ETCD_SSL_DIR}:${ETCD_SSL_DIR}:ro \
+              ${FLANNEL_IMG}:${FLANNEL_VER} /opt/bin/flanneld --ip-masq=true
+
+            # Update docker options
+            ExecStartPost=/usr/bin/docker run --net=host --rm --volume=/run:/run \
+              ${FLANNEL_IMG}:${FLANNEL_VER} \
+              /opt/bin/mk-docker-opts.sh -d /run/flannel_docker_opts.env -i
+
+            [Install]
+            WantedBy=multi-user.target
+
         - name: setup-network-environment.service
           runtime: true
           command: start


### PR DESCRIPTION
Fixes #163 

flanneld 依赖etcd2启动

Fixes #164 

始终使用early-docker来启动flannel，避免新版coreos使用rkt启动flannel带来的问题