### PR TITLE
update registry tls

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -105,6 +105,9 @@ http:
   addr: :5000
   headers:
     X-Content-Type-Options: [nosniff]
+  tls:
+    certificate: /bsroot/tls/bootstrapper.crt
+    key: /bsroot/tls/bootstrapper.key
 health:
   storagedriver:
     enabled: true


### PR DESCRIPTION
上次提交registry tls pr时，忘了提交这部分的修改，需要指定registry证书所在位置