### PR TITLE
Polishing bsroot.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *~
 *.test
 vm
+bsroot

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -166,7 +166,7 @@ prepare_cc_server_contents() {
     # TODO(yi): Why (and how could we ) fix the version of kubelet?  Wouldn't it be the same version of Kubernetes we are going to deploy?
     printf "Downloading kubelet v1.2.0 ... "
     wget --quiet -c -P $BSROOT/html/static https://github.com/typhoonzero/kubernetes_binaries/releases/download/v1.2.0/kubelet || { echo "Failed"; exit 1; }
-    chmod +x kubelet
+    chmod +x $BSROOT/html/static/kubelet
     echo "Done"
 
     printf "Copying cloud-config template and cluster-desc.yml ... "

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -40,12 +40,13 @@ download_pxe_images() {
     mkdir -p $BSROOT/tftpboot
 
     printf "Downloading syslinux ... "
-    wget --quiet -c -P $BSROOT/tftpboot https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.gz
+    wget --quiet -c -P $BSROOT/tftpboot https://www.kernel.org/pub/linux/utils/boot/syslinux/syslinux-6.03.tar.gz || { echo "Failed"; exit 1; }
     cd $BSROOT/tftpboot
-    tar xzf syslinux-6.03.tar.gz
-    cp syslinux-6.03/bios/core/pxelinux.0 $BSROOT/tftpboot
-    cp syslinux-6.03/bios/com32/menu/vesamenu.c32 $BSROOT/tftpboot
-    cp syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 $BSROOT/tftpboot
+    tar xzf syslinux-6.03.tar.gz || { echo "Failed"; exit 1; }
+    cp syslinux-6.03/bios/core/pxelinux.0 $BSROOT/tftpboot || { echo "Failed"; exit 1; }
+    cp syslinux-6.03/bios/com32/menu/vesamenu.c32 $BSROOT/tftpboot || { echo "Failed"; exit 1; }
+    cp syslinux-6.03/bios/com32/elflink/ldlinux/ldlinux.c32 $BSROOT/tftpboot || { echo "Failed"; exit 1; }
+    rm -rf syslinux-6.03 || { echo "Failed"; exit 1; } # Clean the untarred.
     echo "Done"
     
     printf "Importing CoreOS signing key ... "
@@ -191,8 +192,8 @@ EOF
 	mkdir -p $BSROOT/html/static/$VERSION
     fi
     
-    wget --quiet -c -P $BSROOT/html/static/$VERSION https://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2
-    wget --quiet -c -P $BSROOT/html/static/$VERSION https://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2.sig
+    wget --quiet -c -P $BSROOT/html/static/$VERSION https://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2 || { echo "Failed"; exit 1; }
+    wget --quiet -c -P $BSROOT/html/static/$VERSION https://stable.release.core-os.net/amd64-usr/current/coreos_production_image.bin.bz2.sig || { echo "Failed"; exit 1; }
     cd $BSROOT/html/static/$VERSION
     gpg --verify coreos_production_image.bin.bz2.sig > /dev/null 2>&1 || { echo "Failed"; exit 1; }
 

--- a/cloud-config-server/install.sh
+++ b/cloud-config-server/install.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-# FIXME: default to install coreos on /dev/sda
-mac_addr=`ifconfig | grep -A2 'broadcast' | grep -o '..:..:..:..:..:..' | tail -n1`
-wget -O ${mac_addr}.yml http://<HTTP_ADDR>/cloud-config/${mac_addr}
-sudo coreos-install -d /dev/sda -c ${mac_addr}.yml -b http://<HTTP_ADDR>/static -V current
-sudo reboot


### PR DESCRIPTION
Fixes https://github.com/k8sp/sextant/issues/177
Fixes https://github.com/k8sp/sextant/issues/175
Fixes https://github.com/k8sp/sextant/issues/173

I verified this change by running the changed `bsroot.sh` on my iMac -- **but not yet in vm-cluster or a real cluster**.  To run this script:

```
go get github.com/k8sp/sextant
cd /tmp
$GOPATH/src/github.com/k8sp/sextant/bsroot.sh $GOPATH/src/github.com/k8sp/sextant/cloud-config-server/template/unisound-ailab/build_config.yml
```

Above commands generates `/tmp/bsroot` and prints the following progress information:

```
$ ../sextant/bsroot.sh ../sextant/cloud-config-server/template/unisound-ailab/build_config.yml 
Using cluster-desc file /Users/yi/work/src/github.com/k8sp/vm-cluster/../sextant/cloud-config-server/template/unisound-ailab/build_config.yml
Using bootstrapper server IP 10.10.10.192
/Users/yi/work/src/github.com/k8sp/vm-cluster/bsroot already exists.  Overwrite without removing it.
Checking prerequisites ... Done
Downloading syslinux ... Done
Importing CoreOS signing key ... Done
Downloading CoreOS PXE vmlinuz image ... Done
Downloading CoreOS PXE CPIO image ... Done
Generating pxelinux.cfg ... Done
Generating dnsmasq.conf ... Done
Generating Docker registry config file ... Done
Downloading setup-network-environment file ... Done
Downloading kubelet v1.2.0 ... chmod: kubelet: No such file or directory
Done
Copying cloud-config template and cluster-desc.yml ... Done
Generating install.sh ... Done
Checking new CoreOS version ... Done
Updating CoreOS images ... Done
Downloading hyperhube image ... Done
Downloading pause image ... Done
Downloading flannel image ... Done
Generating CA TLS assets ... Done
Generating bootstrapper TLS assets ... Done
```

For your ease of review, here is the content in the generated bsroot directory:

```
$ tree bsroot/
bsroot/
├── config
│   ├── cloud-config.template
│   ├── cluster-desc.yml
│   ├── dnsmasq.conf
│   └── registry.yml
├── flannel_0.5.5.tar
├── html
│   └── static
│       ├── 1122.2.0
│       │   ├── 1122.2.0 -> /Users/yi/work/src/github.com/k8sp/vm-cluster/bsroot/html/static/1122.2.0
│       │   ├── bootstrapper.crt
│       │   ├── bootstrapper.csr
│       │   ├── bootstrapper.key
│       │   ├── ca-key.pem
│       │   ├── ca.pem
│       │   ├── ca.srl
│       │   ├── coreos_production_image.bin.bz2
│       │   └── coreos_production_image.bin.bz2.sig
│       ├── cloud-config
│       │   └── install.sh
│       ├── current -> /Users/yi/work/src/github.com/k8sp/vm-cluster/bsroot/html/static/1122.2.0
│       ├── kubelet
│       └── setup-network-environment-1.0.1
├── hyperkube-amd64_v1.2.0.tar
├── pause_2.0.tar
├── registry_data
├── tftpboot
│   ├── CoreOS_Image_Signing_Key.asc
│   ├── coreos_production_pxe.vmlinuz
│   ├── coreos_production_pxe.vmlinuz.sig
│   ├── coreos_production_pxe_image.cpio.gz
│   ├── coreos_production_pxe_image.cpio.gz.sig
│   ├── ldlinux.c32
│   ├── pxelinux.0
│   ├── pxelinux.cfg
│   │   └── default
│   ├── syslinux-6.03.tar.gz
│   └── vesamenu.c32
└── tls
    ├── bootstrapper.crt
    ├── bootstrapper.csr
    ├── bootstrapper.key
    ├── ca-key.pem
    ├── ca.pem
    └── ca.srl
```