### PR TITLE
update create sextant/bsroot/config

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -128,6 +128,7 @@ EOF
 generate_registry_config() {
     printf "Generating Docker registry config file ... "
     mkdir -p $BSROOT/registry_data
+    [ ! -d $BSROOT/config ] && mkdir -p $BSROOT/config
     cat > $BSROOT/config/registry.yml <<EOF
 version: 0.1
 log:


### PR DESCRIPTION
## 描述
因为k8s环境系统已经安装，ip已经固定分配，使用公司统一的dns。
需要在bsroot.sh注释掉需要的函数
check_prerequisites
#download_pxe_images
#generate_pxe_config
#generate_dnsmasq_config
generate_registry_config
prepare_cc_server_contents
download_k8s_images
## 执行结果
![dd](https://cloud.githubusercontent.com/assets/16366286/18709039/91fa39f6-8030-11e6-9517-44d3b7d6af16.png)

我在generate_registry_config()函数添加了创建sextant/bsroot/config目录，如果目录存在就继续往下走，否则就创建。