### PR TITLE
将bootstrapper镜像保存到bsroot目录

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -246,6 +246,11 @@ download_k8s_images () {
     docker save typhoon1986/flannel:$flannel_version > $BSROOT/flannel.tar || { echo "Failed"; exit 1; }
     echo "Done"
 
+    printf "Building bootstrapper image ... "
+    docker build -t bootstrapper . > /dev/null 2>&1 || { echo "Failed"; exit 1; }
+    docker save bootstrapper:latest > $BSROOT/bootstrapper.tar || { echo "Failed"; exit 1; }
+    echo "Done"
+
     # NOTE: we need to run docker load on the bootstrapper server
     # to load these saved images.
 }

--- a/start.sh
+++ b/start.sh
@@ -24,6 +24,13 @@ hyperkube_version=`grep "hyperkube_version:" /bsroot/config/cluster-desc.yml | a
 pause_version=`grep "pause_version:" /bsroot/config/cluster-desc.yml | awk '{print $2}' | sed 's/ //g' | sed -e 's/^"//' -e 's/"$//'`
 flannel_version=`grep "flannel_version:" /bsroot/config/cluster-desc.yml | awk '{print $2}' | sed 's/ //g' | sed -e 's/^"//' -e 's/"$//'`
 
+docker load < /bsroot/bootstrapper.tar
+docker run -d --net=host \
+  --privileged \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v /bsroot:/bsroot \
+  bootstrapper
+
 docker load < /bsroot/hyperkube-amd64.tar
 docker load < /bsroot/pause.tar
 docker load < /bsroot/flannel.tar


### PR DESCRIPTION
将bootstrapper镜像保存到bsroot目录，在start.sh的时候load进去，并运行bootstrapper