### PR TITLE
修复bootstrapper启动顺序逻辑错误

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -3,8 +3,6 @@
 DEFAULT_IPV4=`grep "bootstrapper:" /bsroot/config/cluster-desc.yml | awk '{print $2}' | sed 's/ //g'`
 BOOTATRAPPER_DOMAIN=`grep "dockerdomain:" /bsroot/config/cluster-desc.yml | awk '{print $2}' | sed 's/"//g' | sed 's/ //g'`
 MASTER_HOSTNAME=`grep "kube_master: y" /bsroot/config/cluster-desc.yml -B 5 |grep "mac" | awk '{print $3}' | sed 's/"//g'`
-# update install.sh domain
-sed -i 's/<HTTP_ADDR>/'"$DEFAULT_IPV4"'/g' /bsroot/html/static/cloud-configs/install.sh
 # start dnsmasq
 dnsmasq --log-facility=- -q --conf-file=/bsroot/config/dnsmasq.conf
 # run addons
@@ -52,10 +50,4 @@ for ((i=0;i<len;i++)); do
   docker tag $DOCKER_IMAGE $DOCKER_TAG_NAME
   docker push $DOCKER_TAG_NAME
 done
-docker load < /bsroot/bootstrapper.tar
-docker run -d --net=host \
-  --privileged \
-  -v /var/run/docker.sock:/var/run/docker.sock \
-  -v /bsroot:/bsroot \
-  bootstrapper
 wait


### PR DESCRIPTION
1，删除bootstrapper启动顺序导致的异常，bootstrapper启动后会调start.sh，不是start.sh起bootstrapper
2，删除/bsroot/html/static/cloud-configs/install.sh不必要的替换，bsroot.sh已经替换过这个变量