### PR TITLE
Remove unnecessary downloading

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -162,15 +162,9 @@ prepare_cc_server_contents() {
     # Fetch release binary tarball from github accroding to the versions
     # defined in "cluster-desc.yml"
     hyperkube_version=`grep "hyperkube_version:" $CLUSTER_DESC | awk '{print $2}' | sed 's/ //g' | sed -e 's/^"//' -e 's/"$//'`
-    printf "Downloading and extracting Kubernetes release ${hyperkube_version} ... "
-    wget --quiet -c -O $BSROOT/kubernetes.tar.gz https://github.com/kubernetes/kubernetes/releases/download/$hyperkube_version/kubernetes.tar.gz
-    cd $BSROOT/
-    tar xzf kubernetes.tar.gz || { echo "Failed"; exit 1; }
-    cd $BSROOT/kubernetes/server
-    tar xzf kubernetes-server-linux-amd64.tar.gz || { echo "Failed"; exit 1; }
-    cp $BSROOT/kubernetes/server/kubernetes/server/bin/kubelet $BSROOT/html/static
-    cp $BSROOT/kubernetes/server/kubernetes/server/bin/kubectl $BSROOT
-    rm -rf $BSROOT/kubernetes
+    printf "Downloading and kubelet and kubectl of release ${hyperkube_version} ... "
+    wget --quiet -c -O $BSROOT/html/static/kubelet https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/linux/amd64/kubelet
+    wget --quiet -c -O $BSROOT/kubectl https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/linux/amd64/kubectl
     chmod +x $BSROOT/html/static/kubelet
     echo "Done"
 


### PR DESCRIPTION
It's a waste of time to download the 1.4 GB sized kubernetes.tar.gz for
just the kubelet and kubectl which are about 160 MB in total.

Resolves #206 