### PR TITLE
Edit build.bash to make sure it can run on Linux or non-Linux systems

### DIFF
--- a/docker/build.bash
+++ b/docker/build.bash
@@ -1,9 +1,15 @@
 #!/bin/bash
 
-if go install \
+THIS_OS=$(go env | grep 'GOOS=' | cut -f 2 -d '=')
+
+if GOOS=linux GOARCH=amd64 go install \
       github.com/k8sp/sextant/cloud-config-server \
       github.com/k8sp/sextant/addons; \
 then
-   cp $GOPATH/bin/{cloud-config-server,addons} .
+   if [[ $THIS_OS != '"linux"' ]]; then
+       cp $GOPATH/bin/linux_amd64/{cloud-config-server,addons} .
+   else
+       cp $GOPATH/bin/{cloud-config-server,addons} .
+   fi
    docker build -t bootstrapper .
 fi

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 THIS_OS=$(go env | grep 'GOOS=' | cut -f 2 -d '=')
+THIS_ARCH=$(go env | grep 'GOARCH=' | cut -f 2 -d '=')
 
 if GOOS=linux GOARCH=amd64 go install \
       github.com/k8sp/sextant/cloud-config-server \
       github.com/k8sp/sextant/addons; \
 then
-   if [[ $THIS_OS != '"linux"' ]]; then
+   if [[ $THIS_OS != '"linux"' || $THIS_ARCH != '"amd64"' ]]; then
        cp $GOPATH/bin/linux_amd64/{cloud-config-server,addons} .
    else
        cp $GOPATH/bin/{cloud-config-server,addons} .


### PR DESCRIPTION
Fixes https://github.com/k8sp/sextant/issues/242

为了让build.bash在任何操作系统执行时，都把cloud-config-server和addons编译成 linux_amd64 格式的可执行文件，我引入了cross-compilation。

如果执行 build.bash 的机器恰好就是 linux_amd64，那么生成的文件在 $GOPATH/bin；否则（cross-compilation生效）结果在 $GOPATH/bin/linux_amd64。