### PR TITLE
Make sure to build fully statically-linked Go programs

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,6 @@ make PREFIX=/go clean binaries && \
 mkdir -p /etc/docker/registry && \
 cp /go/src/github.com/docker/distribution/cmd/registry/config-dev.yml /etc/docker/registry/config.yml
 
-RUN mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 # TODO(yi): Why do we need to create /go/static?
 RUN mkdir /go/static
 

--- a/docker/build.bash
+++ b/docker/build.bash
@@ -3,7 +3,9 @@
 THIS_OS=$(go env | grep 'GOOS=' | cut -f 2 -d '=')
 THIS_ARCH=$(go env | grep 'GOARCH=' | cut -f 2 -d '=')
 
-if GOOS=linux GOARCH=amd64 go install \
+# CGO_ENABLED=0 builds fully statically-linked programs. https://github.com/wangkuiyi/build-statically-linked-go-programs.
+# GOOS=linux GOARCH=amd64 cross-compiles and generates Linux 64-bit programs.
+if CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go install \
       github.com/k8sp/sextant/cloud-config-server \
       github.com/k8sp/sextant/addons; \
 then


### PR DESCRIPTION
Fixes https://github.com/k8sp/sextant/issues/260

Fixes https://github.com/k8sp/sextant/issues/224 , which was not completely resolved by https://github.com/k8sp/sextant/pull/252

For a thorough experiment that support this change, please refer to https://github.com/wangkuiyi/build-statically-linked-go-programs