### PR TITLE
Let bsroot.sh can have the second parameter to specify bsroot directory

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # bsroot.sh creates the $PWD/bsroot directory, which is supposed to be
 # scp-ed to the bootstrapper server as /bsroot.
 
-if [[ "$#" -ne 1 ]]; then
-    echo "Usage: bsroot.sh <cluster-desc.yml>"
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+    echo "Usage: bsroot.sh <cluster-desc.yml> [\$SEXTANT_DIR/bsroot]"
     exit 1
 fi
 
@@ -17,17 +17,22 @@ CLOUD_CONFIG_TEMPLATE=$(realpath $(dirname $0)/cloud-config-server/template/clou
 CLUSTER_DESC=$(realpath $1)
 SEXTANT_DIR=$(realpath $(dirname $0))
 
+if [[ "$#" == 2 ]]; then
+    BSROOT=$2
+else
+    BSROOT=$SEXTANT_DIR/bsroot
+fi
+
+if [[ -d $BSROOT ]]; then
+    echo "$BSROOT already exists.  Overwrite without removing it."
+fi
+
 BS_IP=`grep "bootstrapper:" $CLUSTER_DESC | awk '{print $2}' | sed 's/ //g'`
 if [[ "$?" -ne 0 ||  "$BS_IP" == "" ]]; then
     echo "Failed parsing cluster-desc file $CLUSTER_DESC for bootstrapper IP".
     exit 1
 fi
 echo "Using bootstrapper server IP $BS_IP"
-
-BSROOT=$PWD/bsroot
-if [[ -d $BSROOT ]]; then
-    echo "$BSROOT already exists.  Overwrite without removing it."
-fi
 
 
 check_prerequisites() {


### PR DESCRIPTION
@lipeng-unisound 开会时候提到：

- 目前的bsroot.sh输出./bsroot。但是 @lipeng-unisound 习惯把输出放到 /bsroot。所以每次 `mv ./bsroot /bsroot`之后，再次运行 bsroot.sh 时就会从头下载。

所以我做了这个修改：

- 让bsroot.sh有第二个可选参数，指定输出目录（bsroot）。如果不指定这个参数，则默认输出是 `$SEXTANT_DIR/bsroot`。

这样， @lipeng-unisound 就可以这样使用 bsroot.sh了：

```
$GOPATH/src/github.com/k8sp/sextant/bsroot.sh some-cluster-desc.yml /bsroot
```

在我自己的iMac上测试，可以正常生成 $SEXTANT_DIR/bsroot 目录：

```
cd ~
export SEXTANT_DIR=$GOPATH/src/github.com/k8sp/sextant
$SEXTANT_DIR/bsroot.sh \
   $SEXTANT_DIR/cloud-config-server/template/unisound-ailab/build_config.yml 
```