### PR TITLE
Add setting up kubectl - Yancey

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.test
 vm
 bsroot
+vm-cluster/.vagrant

--- a/addons/addons.go
+++ b/addons/addons.go
@@ -13,6 +13,14 @@ import (
 )
 
 type addonsConfig struct {
+	Bootstrapper    string
+	DomainName      string
+	IPLow           string
+	IPHigh          string
+	Netmask         string
+	Routers         []string
+	NameServers     []string
+	Broadcast       string
 	IngressReplicas int
 	Dockerdomain    string
 	K8sClusterDNS   string
@@ -27,6 +35,14 @@ func execute(templateFile string, config *clusterdesc.Cluster, w io.Writer) {
 	tmpl := template.Must(template.New("").Parse(string(d)))
 
 	ac := addonsConfig{
+		Bootstrapper:    config.Bootstrapper,
+		DomainName:      config.DomainName,
+		IPLow:           config.IPLow,
+		IPHigh:          config.IPHigh,
+		Netmask:         config.Netmask,
+		Routers:         config.Routers,
+		NameServers:     config.Nameservers,
+		Broadcast:       config.Broadcast,
 		IngressReplicas: config.GetIngressReplicas(),
 		Dockerdomain:    config.Dockerdomain,
 		K8sClusterDNS:   config.K8sClusterDNS,

--- a/addons/template/dnsmasq.conf.template
+++ b/addons/template/dnsmasq.conf.template
@@ -1,0 +1,24 @@
+domain={{ .DomainName }}
+user=root
+dhcp-range={{ .IPLow }},{{ .IPHigh }},{{ .Netmask }},12h
+log-dhcp
+
+dhcp-boot=pxelinux.0
+
+dhcp-option=3,{{range $index, $ele := .Routers}}{{if $index}},{{end}}{{$ele}}{{end}}
+
+dhcp-option=6,{{range $index, $ele := .NameServers}}{{if $index}},{{end}}{{$ele}}{{end}}
+no-hosts
+expand-hosts
+no-resolv
+
+local=/{{ .DomainName }}/
+domain-needed
+
+dhcp-option=28,{{ .Broadcast }}
+
+# FIXME: should add NTP time server
+pxe-prompt="Press F8 for menu.", 5
+pxe-service=x86PC, "Install CoreOS from network server", pxelinux
+enable-tftp
+tftp-root=/bsroot/tftpboot

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # bsroot.sh creates the $PWD/bsroot directory, which is supposed to be
 # scp-ed to the bootstrapper server as /bsroot.
 
-if [[ "$#" -ne 1 ]]; then
-    echo "Usage: bsroot.sh <cluster-desc.yml>"
+if [[ "$#" -lt 1 || "$#" -gt 2 ]]; then
+    echo "Usage: bsroot.sh <cluster-desc.yml> [\$SEXTANT_DIR/bsroot]"
     exit 1
 fi
 
@@ -17,17 +17,22 @@ CLOUD_CONFIG_TEMPLATE=$(realpath $(dirname $0)/cloud-config-server/template/clou
 CLUSTER_DESC=$(realpath $1)
 SEXTANT_DIR=$(realpath $(dirname $0))
 
+if [[ "$#" == 2 ]]; then
+    BSROOT=$2
+else
+    BSROOT=$SEXTANT_DIR/bsroot
+fi
+
+if [[ -d $BSROOT ]]; then
+    echo "$BSROOT already exists.  Overwrite without removing it."
+fi
+
 BS_IP=`grep "bootstrapper:" $CLUSTER_DESC | awk '{print $2}' | sed 's/ //g'`
 if [[ "$?" -ne 0 ||  "$BS_IP" == "" ]]; then
     echo "Failed parsing cluster-desc file $CLUSTER_DESC for bootstrapper IP".
     exit 1
 fi
 echo "Using bootstrapper server IP $BS_IP"
-
-BSROOT=$PWD/bsroot
-if [[ -d $BSROOT ]]; then
-    echo "$BSROOT already exists.  Overwrite without removing it."
-fi
 
 
 check_prerequisites() {
@@ -185,6 +190,7 @@ prepare_cc_server_contents() {
     cp $SEXTANT_DIR/addons/template/ingress.template $BSROOT/config/ingress.template || { echo "Failed"; exit 1; }
     cp $SEXTANT_DIR/addons/template/skydns.template $BSROOT/config/skydns.template || { echo "Failed"; exit 1; }
     cp $SEXTANT_DIR/addons/template/skydns-service.template $BSROOT/config/skydns-service.template || { echo "Failed"; exit 1; }
+    cp $SEXTANT_DIR/addons/template/dnsmasq.conf.template $BSROOT/config/dnsmasq.conf.template || { echo "Failed"; exit 1; }
     echo "Done"
 
     printf "Generating install.sh ... "

--- a/cloud-config-server/template/cloud-config.template
+++ b/cloud-config-server/template/cloud-config.template
@@ -447,7 +447,7 @@ coreos:
             --cluster-dns={{ .K8sClusterDNS }} \
             --cluster-domain=cluster.local \
             --config=/etc/kubernetes/manifests \
-            --hostname-override=${DEFAULT_IPV4} \
+            --hostname-override={{ .Hostname }} \
             --api-servers=https://{{ .MasterHostname }}:443 \
             --kubeconfig=/etc/kubernetes/worker-kubeconfig.yaml \
             --tls-private-key-file=/etc/kubernetes/ssl/worker-key.pem \

--- a/clusterdesc/config.go
+++ b/clusterdesc/config.go
@@ -26,7 +26,7 @@ type Cluster struct {
 	Routers       []string
 	Broadcast     string
 	Nameservers   []string
-	DomainName    string `yaml:"domain_name"`
+	DomainName    string `yaml:"domainname"`
 	IPLow, IPHigh string // The IP address range of woker nodes.
 	Nodes         []Node // Enlist nodes that run Kubernetes/etcd/Ceph masters.
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,15 +4,23 @@ dnsmasq --log-facility=- -q --conf-file=/bsroot/config/dnsmasq.conf
 # run addons
 addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
   -template-file /bsroot/config/ingress.template \
-  -config-file /bsroot/html/static/ingress.yaml &
+  -config-file /bsroot/html/static/ingress.yaml || \
+  { echo 'gen ingress failed!' ; exit 1; }
 
 addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
   -template-file /bsroot/config/skydns.template \
-  -config-file /bsroot/html/static/skydns.yaml &
+  -config-file /bsroot/html/static/skydns.yaml || \
+  { echo 'gen skydns failed!' ; exit 1; }
 
 addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
     -template-file /bsroot/config/skydns-service.template \
-    -config-file /bsroot/html/static/skydns-service.yaml &
+    -config-file /bsroot/html/static/skydns-service.yaml || \
+    { echo 'gen skydns-service failed!' ; exit 1; }
+
+addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
+    -template-file /bsroot/config/dnsmasq.conf.template \
+    -config-file /bsroot/config/dnsmasq.conf || \
+    { echo 'gen dnsmasq.conf failed!' ; exit 1; }
 
 # start cloud-config-server
 cloud-config-server -addr ":80" \

--- a/setup-kubectl.bash
+++ b/setup-kubectl.bash
@@ -5,42 +5,19 @@ realpath() {
     [[ $1 = /* ]] && echo "$1" || echo "$PWD/${1#./}"
 }
 
+KUBE_MASTER_HOSTNAME=<KUBE_MASTER_HOSTNAME>
+HYPERKUBE_VERSION=<HYPERKUBE_VERSION>
+
 setup_kubectl() {
-  input_dir=$1
-  output_dir=$2
-  ca_cert="$input_dir/ca.pem"
-  admin_key="$output_dir/admin-key.pem"
-  admin_cert="$output_dir/admin.pem"
-  mkdir -p "$output_dir"
   # Download kubectl binary
   OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-  hyperkube_version=`grep "hyperkube:" "$input_dir/cluster-desc.yml" | grep -o '".*hyperkube.*:.*"' | sed 's/".*://; s/"//'`
-  wget --quiet -c -O "$output_dir/kubectl" https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/$OS/amd64/kubectl
-  chmod +x kubectl/kubectl
-  # Generate TLS keys
-  openssl genrsa -out "$admin_key" 2048
-  openssl req -new -key "$admin_key" -out "$output_dir/admin.csr" -subj "/CN=kube-admin"
-  openssl x509 -req -in "$output_dir/admin.csr" -CA "$input_dir/ca.pem" -CAkey "$input_dir/ca-key.pem" -CAcreateserial -out "$admin_cert" -days 365
+  wget --quiet -c -O "./kubectl" https://storage.googleapis.com/kubernetes-release/release/$HYPERKUBE_VERSION/bin/$OS/amd64/kubectl
+  chmod +x ./kubectl
   # Configure kubectl
-  kube_master_hostname=`head -n $(grep -n 'kube_master\s*:\s*y' "$input_dir/cluster-desc.yml" | cut -d: -f1) "$input_dir/cluster-desc.yml" | grep mac: | tail | grep -o '..:..:..:..:..:..' | tr ':' '-'`
-  echo $kube_master_hostname
-  kubectl config set-cluster default-cluster --server=https://$kube_master_hostname --certificate-authority=${ca_cert}
-  kubectl config set-credentials default-admin --certificate-authority=${ca_cert} --client-key=${admin_key} --client-certificate=${admin_cert}
-  kubectl config set-context default-system --cluster=default-cluster --user=default-admin
-  kubectl config use-context default-system
+  echo $KUBE_MASTER_HOSTNAME
+  ./kubectl config set-cluster default-cluster --server=https://$KUBE_MASTER_HOSTNAME:8080
+  ./kubectl config set-context default-system --cluster=default-cluster
+  ./kubectl config use-context default-system
 }
 
-if [[ "$#" -ne 2 ]]; then
-    echo "Usage: bsroot.sh <input_dir> <output_dir>"
-    echo
-    echo "<input_dir> must contain the following files:"
-    echo "- ca.pem"
-    echo "- ca-key.pem"
-    echo "- cluster-desc.yml"
-    echo "<output_dir> will have the following output files:"
-    echo "- kubectl: the binary file"
-    echo "- admin.pem and admin-key.pem: TLS keys for kubectl to communicate with kube-master"
-    exit 1
-fi
-
-setup_kubectl $(realpath $1) $(realpath $2)
+setup_kubectl

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -29,7 +29,9 @@ mkdir -p /etc/docker/certs.d/bootstrapper:5000
 rm -rf /etc/docker/certs.d/bootstrapper:5000/*
 cp $BSROOT/tls/ca.pem /etc/docker/certs.d/bootstrapper:5000/ca.crt
 
-echo "127.0.0.1 bootstrapper" >> /etc/hosts
+if ! grep -q "127.0.0.1 bootstrapper" /etc/hosts
+  then echo "127.0.0.1 bootstrapper" >> /etc/hosts
+fi
 
 docker load < $BSROOT/bootstrapper.tar > /dev/null 2>&1 || { echo "Docker can not load bootstrapper.tar!"; exit 1; }
 docker run -d --net=host \

--- a/vm-cluster/README.md
+++ b/vm-cluster/README.md
@@ -1,0 +1,77 @@
+## vm-cluster 自动化安装k8s
+### 环境准备
+
+| 虚拟机        | 角色       　|网络组成　|
+| ------------- |-------------| ----|
+| bootstrapper  | dnsmasq(dhcp,dns),cloudconfig server,boorstrapper server,registry|eth0 nat网络,eth1内部网络 ,eth2 hostonly网络|
+| master        | k8s master      |eth0 内部网络|
+| worker        | k8s worker     |eth0 内部网络|
+
+注意:    
+1,内部网络用于三台虚拟机之间相互通信使用    
+2,vagrant的挂载需要依赖hostonly网卡
+
+### 操作步骤
+
+１．修改 vagrantfile 中 cluster-desc.yml.template配置
+
+２．启动bootstrapper
+```
+cd vm-cluster
+./prepare_install_bootstrapper.sh
+vagrant up bootstrapper
+```
+
+* 执行 bsroot.sh 脚本(下载pxe镜像,生成 pxe 的配置，dns dhcp配置，registry 配置,配置 cloudconfig server 环境,下载k8s依赖镜像）
+
+３．启动 k8s master，安装 k8s master 节点
+```
+cd vm-cluster
+vagrant up　master
+```
+启动的过程成会弹出 virtualbox 窗口，在窗口中会出现如下提示：
+```
+Press F8 for menu.(5)
+```
+按 F8 后,会出现从网络安装 CoreOS 的提示如下提示：
+```
+Install CoreOS from network server
+```
+直接按 enter，然后开始从 pxe server 加载 coreos 镜像    
+注意：coreos 首次仅仅是内存安装，可以通过 jounalctl -xef 查看系统日志，当提示 coreos 硬盘安装成功后系统会重启。
+重启后，coreos 虚拟机会根据 cloudconfig 配置文件自动化安装k8s。可以通过在 bootstrapper　vm上ssh core@master 免密码连接 master　vm。几分钟后，可以通过docker ps查看 k8s master 是否启动成功
+ 
+４．安装 k8s worker 节点参考 master 节点安装步骤
+
+###troubleshooting
+
+问题１：
+```
+Stderr: VBoxManage: error: Implementation of the USB 2.0 controller not found!
+```
+解决办法：
+```
+To fix this problem, install the 'Oracle VM VirtualBox Extension Pack'
+```
+https://www.virtualbox.org/wiki/Downloads 可以下载安装最新的VirtualBox和Extension Pack
+* VirtualBox 5.1.4 for Linux hosts
+* VirtualBox 5.1.4 Oracle VM VirtualBox Extension Pack
+
+问题２：
+```
+Error response from daemon: client is newer than server (client API version: 1.23, server API version: 1.22)
+```
+解决办法：
+修改 Dockerfile，添加如何参数,　指定 docker api 的版本为1.22,可以解决版本不一致的问题
+```
+ENV DOCKER_API_VERSION=1.22
+```
+
+问题３：    
+无法找到 pxe server    
+解决办法：
+删除 dnsmasq.conf 中如下两行
+```
+ interface=eth0
+ bind-interfaces
+```

--- a/vm-cluster/Vagrantfile
+++ b/vm-cluster/Vagrantfile
@@ -1,0 +1,53 @@
+# coding: utf-8
+$update_channel = "alpha"
+$image_version = "current"
+
+Vagrant.configure("2") do |config|
+
+   config.vm.provision "shell", inline: <<-SHELL
+     echo '192.168.8.101 bootstrapper' >> /etc/hosts
+     echo "search k8s.baifendian.com" >> /etc/resolv.conf
+   SHELL
+
+  #定义boostrapper虚拟机
+  config.vm.define "bootstrapper" do |bs|
+    bs.vm.box = "coreos-stable"
+    bs.vm.box_url = "https://storage.googleapis.com/stable.release.core-os.net/amd64-usr/current/coreos_production_vagrant.json" % [$update_channel, $image_version]
+    bs.vm.hostname = "bootstrapper"
+    #创建内部网卡，便于和其他虚拟机通信
+    bs.vm.network "private_network", ip: "192.168.8.101",virtualbox__intnet: true
+    #将本地目录挂载到bootstrapper虚拟机
+    bs.vm.synced_folder "./../bsroot", "/bsroot", type: "nfs"
+    #挂载的时候，需要依赖hostonly网卡
+    bs.vm.network "private_network", ip: "192.168.50.4", :adapter=>3
+    bs.vm.provision "shell", path: "provision_bootstrapper_vm.sh"
+    bs.vm.provider "virtualbox" do |vb|
+      vb.gui = false
+      vb.memory = "2048"
+    end
+  end
+
+   # 定义k8s master虚拟机
+   config.vm.define "master" do |master|
+      master.vm.box ="c33s/empty"
+      master.ssh.insert_key = false
+      master.vm.network  "private_network", type: "dhcp", virtualbox__intnet: true, :mac => "0800274a2da1", :adapter=>1, auto_config: false
+      master.vm.provider "virtualbox" do |ms|
+         ms.gui = true
+    	 ms.memory = "1024"
+    	 ms.customize ["modifyvm", :id, "--boot1", "disk", "--boot2", "net", "--usb", "off", "--usbehci", "off"]
+      end
+   end
+
+   #定义worker虚拟机
+   config.vm.define "worker" do |worker|
+      worker.vm.box ="c33s/empty"
+      worker.ssh.insert_key = false
+      worker.vm.network  "private_network", type: "dhcp", virtualbox__intnet: true, :adapter=>1, auto_config: false
+      worker.vm.provider "virtualbox" do |wk|
+         wk.gui = true
+         wk.memory = "1024"
+         wk.customize ["modifyvm", :id, "--boot1", "disk", "--boot2", "net", "--macaddress1", "auto", "--usb", "off", "--usbehci", "off"]
+      end
+   end
+end

--- a/vm-cluster/cluster-desc.yml.template
+++ b/vm-cluster/cluster-desc.yml.template
@@ -1,0 +1,33 @@
+bootstrapper: 192.168.8.101
+subnet: 192.168.8.0
+netmask: 255.255.255.0
+iplow: 192.168.8.201
+iphigh: 192.168.8.220
+routers: [192.168.8.101]
+broadcast: 192.168.8.255
+nameservers: [192.168.8.101, 8.8.8.8, 8.8.4.4]
+domainname: "k8s.baifendian.com"
+dockerdomain: "bootstrapper"
+k8s_service_cluster_ip_range: 192.168.0.0/24
+k8s_cluster_dns: 192.168.0.10
+
+images:
+  hyperkube: "typhoon1986/hyperkube-amd64:v1.3.6"
+  pause: "typhoon1986/pause-amd64:3.0"
+  flannel: "typhoon1986/flannel:0.5.5"
+  ingress: "yancey1989/nginx-ingress-controller:0.8.3"
+  kube2sky: "yancey1989/kube2sky:1.14"
+  healthz: "typhoon1986/exechealthz:1.0"
+  addon_manager: "yancey1989/kube-addon-manager-amd64:v5.1"
+  skydns: "typhoon1986/skydns:latest"
+
+nodes:
+  - mac: "08:00:27:4a:2d:a1"
+    ceph_monitor: n
+    kube_master: y
+    etcd_member: y
+    ingress_label: n
+
+ssh_authorized_keys: |1+
+    - "<SSH_KEY>"
+

--- a/vm-cluster/prepare_install_bootstrapper.sh
+++ b/vm-cluster/prepare_install_bootstrapper.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# In addition to run bsroot.sh to generate bsroot directory, this
+# script also creates a SSH key pair and copies it to bootstrapper VM
+# and to other VMs via cloud-config file.  So that all these VMs can
+# SSH to each other without password.
+
+# Create a temporary directory in OS X or
+# Linux. c.f. http://unix.stackexchange.com/questions/30091/fix-or-alternative-for-mktemp-in-os-x
+TMPDIR=$(mktemp -d 2>/dev/null || mktemp -d -t '/tmp')
+
+# Generate the SSH public/private key pair.
+rm -rf $TMPDIR/*
+ssh-keygen -t rsa -f $TMPDIR/id_rsa -P ''
+
+# Replace the public key into cluster-desc.yml.template and generate cluster-desc.yml
+PUB_KEY=$(cat $TMPDIR/id_rsa.pub)
+SEXTANT_DIR=$GOPATH/src/github.com/k8sp/sextant
+sed -e 's#<SSH_KEY>#'"$PUB_KEY"'#' $SEXTANT_DIR/vm-cluster/cluster-desc.yml.template > $TMPDIR/cluster-desc.yml
+
+# Generate $SEXTANT_DIR/bsroot
+cd $SEXTANT_DIR
+./bsroot.sh $TMPDIR/cluster-desc.yml
+
+# Put SSH keys into $SEXTANT_DIR/bsroot, which will be mounted to the bootstrapper VM.
+mv $TMPDIR/* $SEXTANT_DIR/bsroot/vm-keys
+

--- a/vm-cluster/prepare_install_bootstrapper.sh
+++ b/vm-cluster/prepare_install_bootstrapper.sh
@@ -24,4 +24,3 @@ cd $SEXTANT_DIR
 
 # Put SSH keys into $SEXTANT_DIR/bsroot, which will be mounted to the bootstrapper VM.
 mv $TMPDIR/* $SEXTANT_DIR/bsroot/vm-keys
-

--- a/vm-cluster/provision_bootstrapper_vm.sh
+++ b/vm-cluster/provision_bootstrapper_vm.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copy VM keys out from /bsroot/vm-keys.
+mkdir -p /root/.ssh
+rm -rf /root/.ssh/*
+cp /bsroot/vm-keys/* /root/.ssh
+cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+
+#修复无法找到pxe　server的异常
+sed -i '/interface=eth0/,/bind-interfaces/d' /bsroot/config/dnsmasq.conf
+
+cd /bsroot
+./start_bootstrapper_container.sh /bsroot


### PR DESCRIPTION
简化了kubectl的配置过程，做了如下修改:
* merge 了master的代码，可使用vm-cluster进行测试了。
* 在"笔记本上" 执行bsroot.sh 期间会将cluster-desc中kube-master-hostname,hyperkube-version信息写入setup-kubectl.bash中
* 在kubernetes client的机器上将setup-kubectl.bash 以scp的方式获取下来，脚本会根据系统类型下载对应kubectl的二进制文件并自动配置到集群的master节点。
* 将通过TLS认证的连接方式改为连接非认证的8080端口。


