### PR TITLE
Add upstream DNS

### DIFF
--- a/addons/template/dnsmasq.conf.template
+++ b/addons/template/dnsmasq.conf.template
@@ -3,21 +3,23 @@ user=root
 dhcp-range={{ .IPLow }},{{ .IPHigh }},{{ .Netmask }},12h
 log-dhcp
 
-dhcp-boot=pxelinux.0
 
+dhcp-option=28,{{ .Broadcast }}
 dhcp-option=3,{{range $index, $ele := .Routers}}{{if $index}},{{end}}{{$ele}}{{end}}
-
 dhcp-option=6,{{range $index, $ele := .NameServers}}{{if $index}},{{end}}{{$ele}}{{end}}
+
 no-hosts
 expand-hosts
 no-resolv
+server=8.8.8.8
+server=8.8.4.4
 
 local=/{{ .DomainName }}/
 domain-needed
 
-dhcp-option=28,{{ .Broadcast }}
 
 # FIXME: should add NTP time server
+dhcp-boot=pxelinux.0
 pxe-prompt="Press F8 for menu.", 5
 pxe-service=x86PC, "Install CoreOS from network server", pxelinux
 enable-tftp

--- a/cloud-config-server/template/unisound-ailab/build_config.yml
+++ b/cloud-config-server/template/unisound-ailab/build_config.yml
@@ -5,7 +5,7 @@ iplow: 10.10.10.201
 iphigh: 10.10.10.220
 routers: [10.10.10.192]
 broadcast: 10.10.10.255
-nameservers: [10.10.10.192, 8.8.8.8, 8.8.4.4]
+nameservers: [10.10.10.192]
 domainname: "ailab.unisound.com"
 dockerdomain: "bootstrapper"
 k8s_service_cluster_ip_range: 10.100.0.0/24


### PR DESCRIPTION
在 `dnsmasq.conf` 中添加 upstream DNS, 当解析 dnsmasq 无法处理的域名时， 通过 upstream DNS 解析