### PR TITLE
make dnsmasq upstream config from cluster-desc

### DIFF
--- a/addons/addons.go
+++ b/addons/addons.go
@@ -13,19 +13,20 @@ import (
 )
 
 type addonsConfig struct {
-	Bootstrapper    string
-	DomainName      string
-	IPLow           string
-	IPHigh          string
-	Netmask         string
-	Routers         []string
-	NameServers     []string
-	Broadcast       string
-	IngressReplicas int
-	Dockerdomain    string
-	K8sClusterDNS   string
-	EtcdEndpoint    string
-	Images          map[string]string
+	Bootstrapper        string
+	DomainName          string
+	IPLow               string
+	IPHigh              string
+	Netmask             string
+	Routers             []string
+	NameServers         []string
+	UpstreamNameServers []string
+	Broadcast           string
+	IngressReplicas     int
+	Dockerdomain        string
+	K8sClusterDNS       string
+	EtcdEndpoint        string
+	Images              map[string]string
 }
 
 func execute(templateFile string, config *clusterdesc.Cluster, w io.Writer) {
@@ -35,19 +36,20 @@ func execute(templateFile string, config *clusterdesc.Cluster, w io.Writer) {
 	tmpl := template.Must(template.New("").Parse(string(d)))
 
 	ac := addonsConfig{
-		Bootstrapper:    config.Bootstrapper,
-		DomainName:      config.DomainName,
-		IPLow:           config.IPLow,
-		IPHigh:          config.IPHigh,
-		Netmask:         config.Netmask,
-		Routers:         config.Routers,
-		NameServers:     config.Nameservers,
-		Broadcast:       config.Broadcast,
-		IngressReplicas: config.GetIngressReplicas(),
-		Dockerdomain:    config.Dockerdomain,
-		K8sClusterDNS:   config.K8sClusterDNS,
-		EtcdEndpoint:    strings.Split(config.GetEtcdEndpoints(), ",")[0],
-		Images:          config.Images,
+		Bootstrapper:        config.Bootstrapper,
+		DomainName:          config.DomainName,
+		IPLow:               config.IPLow,
+		IPHigh:              config.IPHigh,
+		Netmask:             config.Netmask,
+		Routers:             config.Routers,
+		NameServers:         config.Nameservers,
+		UpstreamNameServers: config.UpstreamNameServers,
+		Broadcast:           config.Broadcast,
+		IngressReplicas:     config.GetIngressReplicas(),
+		Dockerdomain:        config.Dockerdomain,
+		K8sClusterDNS:       config.K8sClusterDNS,
+		EtcdEndpoint:        strings.Split(config.GetEtcdEndpoints(), ",")[0],
+		Images:              config.Images,
 	}
 	candy.Must(tmpl.Execute(w, ac))
 }

--- a/addons/template/dnsmasq.conf.template
+++ b/addons/template/dnsmasq.conf.template
@@ -11,8 +11,9 @@ dhcp-option=6,{{range $index, $ele := .NameServers}}{{if $index}},{{end}}{{$ele}
 no-hosts
 expand-hosts
 no-resolv
-server=8.8.8.8
-server=8.8.4.4
+{{range $index, $ele := .UpstreamNameServers}}
+server={{$ele}}
+{{end}}
 
 local=/{{ .DomainName }}/
 domain-needed

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -60,7 +60,7 @@ source $SEXTANT_DIR/bsroot_lib.bash
 check_prerequisites() {
     printf "Checking prerequisites ... "
     err=0
-    for tool in wget tar gpg docker tr go; do
+    for tool in wget tar gpg docker tr go make; do
         command -v $tool >/dev/null 2>&1 || { echo "Install $tool before run this script"; err=1; }
     done
     if [[ $err -ne 0 ]]; then
@@ -177,7 +177,7 @@ prepare_cc_server_contents() {
     printf "Copying bsroot_lib.bash ... "
     cp $SEXTANT_DIR/bsroot_lib.bash $BSROOT/ || { echo "Failed"; exit 1; }
     echo "Done"
-    
+
     printf "Copying addon templates ... "
     cp $SEXTANT_DIR/addons/template/ingress.template $BSROOT/config/ingress.template || { echo "Failed"; exit 1; }
     cp $SEXTANT_DIR/addons/template/skydns.template $BSROOT/config/skydns.template || { echo "Failed"; exit 1; }
@@ -253,7 +253,7 @@ build_bootstrapper_image() {
                github.com/k8sp/sextant/addons \
         || { echo "Failed"; exit 1; }
     echo "Done"
-    
+
     if [[ $THIS_OS != '"linux"' || $THIS_ARCH != '"amd64"' ]]; then
         cp $GOPATH/bin/linux_amd64/{cloud-config-server,addons} $SEXTANT_DIR/docker
     else
@@ -268,7 +268,7 @@ build_bootstrapper_image() {
         && make CGO_ENABLED=0 GOOS=linux GOARCH=amd64 PREFIX=$GOPATH clean $GOPATH/bin/registry >/dev/null 2>&1\
         || { echo "Failed"; exit 1; }
     echo "Done"
-    
+
     if [[ $THIS_OS != '"linux"' || $THIS_ARCH != '"amd64"' ]]; then
         cp $GOPATH/bin/linux_amd64/registry $SEXTANT_DIR/docker
     else
@@ -282,7 +282,7 @@ build_bootstrapper_image() {
     # NOTE: we need to run docker load on the bootstrapper server
     # to load these saved images.
     echo "Done"
-    
+
     cp $SEXTANT_DIR/start_bootstrapper_container.sh \
        $BSROOT/start_bootstrapper_container.sh 2>&1 || { echo "Failed"; exit 1; }
     chmod +x $BSROOT/start_bootstrapper_container.sh

--- a/cloud-config-server/template/unisound-ailab/build_config.yml
+++ b/cloud-config-server/template/unisound-ailab/build_config.yml
@@ -6,6 +6,7 @@ iphigh: 10.10.10.220
 routers: [10.10.10.192]
 broadcast: 10.10.10.255
 nameservers: [10.10.10.192]
+upstreamnameservers: [8.8.8.8, 8.8.4.4]
 domainname: "ailab.unisound.com"
 dockerdomain: "bootstrapper"
 k8s_service_cluster_ip_range: 10.100.0.0/24

--- a/clusterdesc/config.go
+++ b/clusterdesc/config.go
@@ -21,14 +21,15 @@ type Cluster struct {
 	// address; otherwise the node will be assigned an IP from
 	// within the range of [IPLow, IPHigh].  In practice, nodes
 	// running etcd members requires fixed IP addresses.
-	Subnet        string
-	Netmask       string
-	Routers       []string
-	Broadcast     string
-	Nameservers   []string
-	DomainName    string `yaml:"domainname"`
-	IPLow, IPHigh string // The IP address range of woker nodes.
-	Nodes         []Node // Enlist nodes that run Kubernetes/etcd/Ceph masters.
+	Subnet              string
+	Netmask             string
+	Routers             []string
+	Broadcast           string
+	Nameservers         []string
+	UpstreamNameServers []string
+	DomainName          string `yaml:"domainname"`
+	IPLow, IPHigh       string // The IP address range of woker nodes.
+	Nodes               []Node // Enlist nodes that run Kubernetes/etcd/Ceph masters.
 
 	CoreOSChannel string `yaml:"coreos_channel"`
 


### PR DESCRIPTION
1. Dnsmasq config template will use cluster-desc "UpstreamNameServers" to setup upstream name servers.
2. bsroot.sh will check reqirements of command "make".

NOTE: lots of code formatting problems