### PR TITLE
Use alpine instead of golang:alpine as the base image of boostrapper

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -20,9 +20,8 @@ CLUSTER_DESC=$(realpath $1)
 
 # Check sextant dir
 if [[ "$SEXTANT_DIR" != "$GOPATH/src/github.com/k8sp/sextant" ]]; then
-    echo "GOPATH: $GOPATH"
-    echo "sextant dir: $SEXTANT_DIR"
-    echo "sextant dir: $SEXTANT_DIR should be $GOPATH/src/github.com/k8sp/sextant"
+    echo "\$SEXTANT_DIR=$SEXTANT_DIR differs from $GOPATH/src/github.com/k8sp/sextant."
+    echo "Please set GOPATH environment variable and use 'go get' to retrieve sextant."
     exit 1
 fi
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,9 @@ apk add --no-cache make git dnsmasq openssl
 
 # Upload Sextant Go programs and retrieve dependencies.
 RUN mkdir -p /go/bin
-COPY cloud-config-server /go/bin/
-COPY addons              /go/bin/
-COPY registry            /go/bin/
+COPY cloud-config-server /
+COPY addons              /
+COPY registry            /
 
 # TODO(yi): Why do we need to create /go/static?
 RUN mkdir /go/static

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
 
 # run addons
-addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
+/addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
   -template-file /bsroot/config/ingress.template \
   -config-file /bsroot/html/static/ingress.yaml || \
   { echo 'gen ingress failed!' ; exit 1; }
 
-addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
+/addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
   -template-file /bsroot/config/skydns.template \
   -config-file /bsroot/html/static/skydns.yaml || \
   { echo 'gen skydns failed!' ; exit 1; }
 
-addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
+/addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
     -template-file /bsroot/config/skydns-service.template \
     -config-file /bsroot/html/static/skydns-service.yaml || \
     { echo 'gen skydns-service failed!' ; exit 1; }
 
-addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
+/addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
     -template-file /bsroot/config/dnsmasq.conf.template \
     -config-file /bsroot/config/dnsmasq.conf || \
     { echo 'gen dnsmasq.conf failed!' ; exit 1; }
@@ -25,7 +25,7 @@ addons -cluster-desc-file /bsroot/config/cluster-desc.yml \
 dnsmasq --log-facility=- -q --conf-file=/bsroot/config/dnsmasq.conf
 
 # start cloud-config-server
-cloud-config-server -addr ":80" \
+/cloud-config-server -addr ":80" \
   -dir /bsroot/html/static \
   -cc-template-file /bsroot/config/cloud-config.template \
   -cc-template-url "" \
@@ -35,6 +35,7 @@ cloud-config-server -addr ":80" \
   -ca-key /bsroot/tls/ca-key.pem &
 
 # start registry
-registry serve /bsroot/config/registry.yml &
+/registry serve /bsroot/config/registry.yml &
 sleep 2
+
 wait

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -21,9 +21,6 @@ if [[ $BSROOT != /* ]]; then
   exit 1
 fi
 
-# push k8s images to registry from bsroot
-BOOTATRAPPER_DOMAIN=`grep "dockerdomain:" $BSROOT/config/cluster-desc.yml | awk '{print $2}' | sed 's/"//g' | sed 's/ //g'`
-
 # Config Registry tls
 mkdir -p /etc/docker/certs.d/bootstrapper:5000
 rm -rf /etc/docker/certs.d/bootstrapper:5000/*
@@ -41,7 +38,7 @@ docker run -d \
        --privileged \
        -v /var/run/docker.sock:/var/run/docker.sock \
        -v $BSROOT:/bsroot \
-       bootstrapper
+       bootstrapper || { echo "Failed"; exit -1; }
 
 # Sleep 3 seconds, waitting for registry started.
 sleep 3
@@ -51,8 +48,12 @@ load_yaml $BSROOT/config/cluster-desc.yml cluster_desc_
 
 for DOCKER_IMAGE in $(set | grep '^cluster_desc_images_' | grep -o '".*"' | sed 's/"//g'); do
   DOCKER_TAR_FILE=$BSROOT/$(echo ${DOCKER_IMAGE}.tar | sed "s/:/_/g" |awk -F'/' '{print $2}')
-  # Do *NOT* remove docker image path when push to bootstrapper registry.
-  LOCAL_DOCKER_URL=`echo $BOOTATRAPPER_DOMAIN:5000/${DOCKER_IMAGE}`
+  # NOTE: It is more precise if we use $cluster_desc_bootstrapper in
+  # the following line than the constant string "bootstrapper", but
+  # the later allows use to add entry "bootstrapper 127.0.0.1" into
+  # /etc/hosts of our work computer and run this script locally as a
+  # test.
+  LOCAL_DOCKER_URL=bootstrapper:5000/${DOCKER_IMAGE}
   docker load < $DOCKER_TAR_FILE
   docker tag $DOCKER_IMAGE $LOCAL_DOCKER_URL
   docker push $LOCAL_DOCKER_URL

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -48,12 +48,7 @@ load_yaml $BSROOT/config/cluster-desc.yml cluster_desc_
 
 for DOCKER_IMAGE in $(set | grep '^cluster_desc_images_' | grep -o '".*"' | sed 's/"//g'); do
   DOCKER_TAR_FILE=$BSROOT/$(echo ${DOCKER_IMAGE}.tar | sed "s/:/_/g" |awk -F'/' '{print $2}')
-  # NOTE: It is more precise if we use $cluster_desc_bootstrapper in
-  # the following line than the constant string "bootstrapper", but
-  # the later allows use to add entry "bootstrapper 127.0.0.1" into
-  # /etc/hosts of our work computer and run this script locally as a
-  # test.
-  LOCAL_DOCKER_URL=bootstrapper:5000/${DOCKER_IMAGE}
+  LOCAL_DOCKER_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
   docker load < $DOCKER_TAR_FILE
   docker tag $DOCKER_IMAGE $LOCAL_DOCKER_URL
   docker push $LOCAL_DOCKER_URL


### PR DESCRIPTION
Fixes https://github.com/k8sp/sextant/issues/236
Fixes https://github.com/k8sp/sextant/issues/314
Fixes https://github.com/k8sp/sextant/issues/123