### PR TITLE
Install cloud-init via kickstart

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -51,7 +51,7 @@ generate_registry_config
 prepare_cc_server_contents
 download_k8s_images
 build_bootstrapper_image
+
 generate_tls_assets
 prepare_setup_kubectl
 generate_addons_config
-generate_rpmrepo_config

--- a/scripts/centos.sh
+++ b/scripts/centos.sh
@@ -84,12 +84,13 @@ clearpart --all
 part / --fstype="xfs" --grow --ondisk=sda --size=1
 part swap --fstype="swap" --ondisk=sda --size=30000
 
-repo --name=base --baseurl="http://mirrors.163.com/centos/7/os/x86_64/"
+repo --name=cloud-init --baseurl=http://$BS_IP/static/CentOS7/repo/cloudinit/
 network --onboot on --bootproto dhcp --noipv6
 
 %packages --ignoremissing
 @Base
 @Core
+cloud-init
 %end
 
 

--- a/scripts/centos.sh
+++ b/scripts/centos.sh
@@ -87,7 +87,7 @@ part swap --fstype="swap" --ondisk=sda --size=30000
 repo --name=cloud-init --baseurl=http://$BS_IP/static/CentOS7/repo/cloudinit/
 network --onboot on --bootproto dhcp --noipv6
 
-%packages --ignoremissing
+%packages # --ignoremissing
 @Base
 @Core
 cloud-init


### PR DESCRIPTION
* Fix #409 , Fix invoking generating rpm function
* Install cloud-init via kickstart
* Remove `ignoremissing` flag in kickstart configuration file