### PR TITLE
Centos install docker etcd flannel

### DIFF
--- a/scripts/bsroot_lib.bash
+++ b/scripts/bsroot_lib.bash
@@ -43,6 +43,30 @@ function parse_yaml() {
     }' | sed 's/_=/+=/g'
 }
 
+## derived from https://gist.github.com/epiloque/8cf512c6d64641bde388
+## works for arrays of hashes, as long as the hashes do not have arrays
+parse_yaml2() {
+    local prefix=$2
+    local s
+    local w
+    local fs
+    s='[[:space:]]*'
+    w='[a-zA-Z0-9_]*'
+    fs="$(echo @|tr @ '\034')"
+    sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
+        -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" "$1" |
+    awk -F"$fs" '{
+      indent = length($1)/2;
+      if (length($2) == 0) { conj[indent]="+";} else {conj[indent]="";}
+      vname[indent] = $2;
+      for (i in vname) {if (i > indent) {delete vname[i]}}
+      if (length($3) > 0) {
+              vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
+              printf("%s%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, conj[indent-1],$3);
+      }
+    }' | sed 's/_=/+=/g'
+}
+
 # load_yaml calls parse_yaml to convert a .yaml file into a temporary
 # .bash file, run the temporary .bash file, and delete it.  So we will
 # have bash variables defined and whose values are values in the .yaml
@@ -55,7 +79,7 @@ function load_yaml() {
     local yaml=$1
     local prefix=$2
     local parsedYaml=$(mktemp /tmp/bsroot-parse-yaml.XXXXX)
-    parse_yaml $yaml $prefix > $parsedYaml
+    parse_yaml2 $yaml $prefix > $parsedYaml
     source $parsedYaml
     rm $parsedYaml
 }

--- a/scripts/bsroot_lib.bash
+++ b/scripts/bsroot_lib.bash
@@ -24,28 +24,10 @@ function check_prerequisites() {
 # 
 #    parse_yaml example.yaml "cluster_desc_" > parseResult.bash
 # 
-function parse_yaml() {
-    local yaml=$1
-    local prefix=$2
-    local s='[[:space:]]*'
-    local w='[a-zA-Z0-9_]*'
-    local fs="$(echo @|tr @ '\034')"
-    sed -ne "s|^\($s\)\($w\)$s:$s\"\(.*\)\"$s\$|\1$fs\2$fs\3|p" \
-        -e "s|^\($s\)\($w\)$s[:-]$s\(.*\)$s\$|\1$fs\2$fs\3|p" $yaml |
-    awk -F"$fs" '{
-    indent = length($1)/2;
-    vname[indent] = $2;
-    for (i in vname) {if (i > indent) {delete vname[i]}}
-        if (length($3) > 0) {
-            vn=""; for (i=0; i<indent; i++) {vn=(vn)(vname[i])("_")}
-            printf("%s%s%s=(\"%s\")\n", "'"$prefix"'",vn, $2, $3);
-        }
-    }' | sed 's/_=/+=/g'
-}
 
 ## derived from https://gist.github.com/epiloque/8cf512c6d64641bde388
 ## works for arrays of hashes, as long as the hashes do not have arrays
-parse_yaml2() {
+parse_yaml() {
     local prefix=$2
     local s
     local w
@@ -79,7 +61,7 @@ function load_yaml() {
     local yaml=$1
     local prefix=$2
     local parsedYaml=$(mktemp /tmp/bsroot-parse-yaml.XXXXX)
-    parse_yaml2 $yaml $prefix > $parsedYaml
+    parse_yaml $yaml $prefix > $parsedYaml
     source $parsedYaml
     rm $parsedYaml
 }

--- a/scripts/centos.sh
+++ b/scripts/centos.sh
@@ -90,6 +90,10 @@ network --onboot on --bootproto dhcp --noipv6
 %packages --ignoremissing
 @Base
 @Core
+cloud-init
+docker
+etcd
+flannel
 %end
 
 
@@ -165,7 +169,7 @@ EOF
              centos:7.2.1511\
              sh -c  '/usr/bin/yum -y install epel-release yum-utils createrepo  && \
              /usr/bin/mkdir  -p /broot/html/static/CentOS7/repo/cloudinit  && \
-             /usr/bin/yumdownloader  --resolve --destdir=/bsroot/html/static/CentOS7/repo/cloudinit cloud-init &&  \
+             /usr/bin/yumdownloader  --resolve --destdir=/bsroot/html/static/CentOS7/repo/cloudinit cloud-init docker etcd flannel &&  \
              /usr/bin/createrepo -v  /bsroot/html/static/CentOS7/repo/cloudinit/' ||  \
              { echo 'Failed to generate  cloud-init repo !' ; exit 1; }
 

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -6,7 +6,7 @@ if [[ "$#" -gt 1 ]]; then
     echo "Usage: start_bootstrapper_container.sh [bsroot-path]"
     exit 1
 elif [[ "$#" -ne 1 ]]; then
-    BSROOT=/bsroot
+    BSROOT=$(cd `dirname $0`; pwd)
 else
     BSROOT=$1
 fi

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -22,9 +22,12 @@ if [[ $BSROOT != /* ]]; then
 fi
 
 if [[ -e "$BSROOT/html/static/current/CentOS-7-x86_64-DVD-1511.iso" ]]; then
-    mkdir -p $BSROOT/html/static/CentOS7/dvd_content
-    sudo umount $BSROOT/html/static/CentOS7/dvd_content
-    sudo mount -t iso9660 -o loop $BSROOT/html/static/CentOS7/CentOS-7-x86_64-DVD-1511.iso $BSROOT/html/static/CentOS7/dvd_content || { echo "Mount iso failed"; exit 1; }
+    if [[ ! -d "$BSROOT/html/static/CentOS7/dvd_content" ]]; then
+        mkdir -p $BSROOT/html/static/CentOS7/dvd_content
+    fi
+    if [[ ! -f "$BSROOT/html/static/CentOS7/dvd_content/.treeinfo" ]]; then
+        sudo mount -t iso9660 -o loop $BSROOT/html/static/CentOS7/CentOS-7-x86_64-DVD-1511.iso $BSROOT/html/static/CentOS7/dvd_content || { echo "Mount iso failed"; exit 1; }
+    fi
 fi
 
 # Config Registry tls


### PR DESCRIPTION
fixes #390 
1. 使用私有源安装docker 、 etcd、flannel
2. start_bootstrapper_container.sh 中默认的 bsroot 不合理的问题。
3. 增加了一个支持解析 yaml 数组的方法 parse_yaml2 ，虽然支持了解析 yaml 中的数组，但仍有一些小问题： ssh-key 中存在空格，会被当做多个 value 存入数组