### PR TITLE
WIP: Download and install nvidia gpu drivers on centos

### DIFF
--- a/bsroot.sh
+++ b/bsroot.sh
@@ -32,7 +32,7 @@ if [[ $cluster_desc_os_name == "CentOS" ]]; then
     generate_post_provision_script
     generate_post_nochroot_provision_script
     generate_rpmrepo_config
-#    build_centos_gpu_drivers
+    build_centos_gpu_drivers
     download_centos_gpu_drivers
 
 elif [[ $cluster_desc_os_name == "CoreOS" ]]; then

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -32,6 +32,8 @@ if [[ $cluster_desc_os_name == "CentOS" ]]; then
     generate_post_provision_script
     generate_post_nochroot_provision_script
     generate_rpmrepo_config
+#    build_centos_gpu_drivers
+    download_centos_gpu_drivers
 
 elif [[ $cluster_desc_os_name == "CoreOS" ]]; then
 

--- a/bsroot.sh
+++ b/bsroot.sh
@@ -32,7 +32,6 @@ if [[ $cluster_desc_os_name == "CentOS" ]]; then
     generate_post_provision_script
     generate_post_nochroot_provision_script
     generate_rpmrepo_config
-    build_centos_gpu_drivers
     download_centos_gpu_drivers
 
 elif [[ $cluster_desc_os_name == "CoreOS" ]]; then

--- a/scripts/centos.sh
+++ b/scripts/centos.sh
@@ -173,3 +173,138 @@ EOF
   echo "Done"
 
 }
+
+
+#build_centos_gpu_drivers() {
+download_centos_gpu_drivers() {
+  printf "Downding CentOS GPU drivers ...\n"
+  [ ! -d $BSROOT/html/static/CentOS7/gpu_drivers ] && mkdir  -p $BSROOT/html/static/CentOS7/gpu_drivers
+
+  DRIVER_VERSION=${1:-352.79}
+  #DRIVER_VERSION=${1:-352.39}
+  CENTOS_VERSION=${3:-7.2.1511}
+  DRIVER_ARCHIVE=NVIDIA-Linux-x86_64-${DRIVER_VERSION}.run
+  DRIVER_DOWNLOAD_FROM=us.download.nvidia.com/XFree86/Linux-x86_64
+  #DRIVER_DOWNLOAD_TO=/home/atlas/bsroot/html/static/CentOS7/gpu/
+  DRIVER_DOWNLOAD_TO=$BSROOT/html/static/CentOS7/gpu_drivers/nvidia_installers/
+  [ ! -d ${DRIVER_DOWNLOAD_TO} ] && mkdir -p ${DRIVER_DOWNLOAD_TO}
+  curl -s -L http://${DRIVER_DOWNLOAD_FROM}/${DRIVER_VERSION}/${DRIVER_ARCHIVE} \
+    -z ${DRIVER_DOWNLOAD_TO}/${DRIVER_ARCHIVE} \
+    -o ${DRIVER_DOWNLOAD_TO}/${DRIVER_ARCHIVE}
+  echo "Done"
+  printf "Generating CentOS GPU drivers build script ...\n"
+  cat > $BSROOT/html/static/CentOS7/gpu_drivers/build_centos_gpu_drivers.sh <<EOF
+#!/bin/bash
+#
+# Build NVIDIA drivers on CentOS
+#
+DRIVER_VERSION=\${1:-${DRIVER_VERSION}}
+CENTOS_VERSION=\${3:-${CENTOS_VERSION}}
+
+DRIVER_ARCHIVE=NVIDIA-Linux-x86_64-\${DRIVER_VERSION}
+DRIVER_ARCHIVE_PATH=\${PWD}/nvidia_installers/\${DRIVER_ARCHIVE}.run
+WORK_DIR=\${PWD}/run_files/\${CENTOS_VERSION}
+ARTIFACT_DIR=\${WORK_DIR}/\${DRIVER_ARCHIVE}
+DRIVER_DOWNLOAD_FROM=10.10.14.253/static/CentOS7/gpu/nvidia_installers/\${DRIVER_ARCHIVE}.run
+
+NVIDIA_DIR=/usr/local/nvidia
+NVIDIA_BIN_DIR=/usr/local/nvidia/bin
+NVIDIA_LIB_DIR=/usr/local/nvidia/lib64
+
+TOOLS="nvidia-debugdump nvidia-cuda-mps-control nvidia-xconfig nvidia-modprobe nvidia-smi nvidia-cuda-mps-server
+nvidia-persistenced nvidia-settings"
+
+if [ ! -f \${DRIVER_ARCHIVE_PATH} ]
+then
+  echo Downloading NVIDIA Linux drivers version \${DRIVER_VERSION}
+  mkdir -p nvidia_installers
+  curl -s -L http://\${DRIVER_DOWNLOAD_FROM} \\
+    -z \${DRIVER_ARCHIVE_PATH} \\
+    -o \${DRIVER_ARCHIVE_PATH}
+fi
+
+yum install -y make kernel-devel gcc
+
+#rm -Rf \${PWD}/tmp
+mkdir -p \${WORK_DIR}
+cp -ul \${DRIVER_ARCHIVE_PATH} \${WORK_DIR}
+
+pushd \${WORK_DIR}
+chmod +x \${DRIVER_ARCHIVE}.run
+rm -Rf ./\${DRIVER_ARCHIVE}
+./\${DRIVER_ARCHIVE}.run -x
+cd \${DRIVER_ARCHIVE}
+./nvidia-installer -s 
+popd
+# Create archives with no paths
+#sh _export.sh \${WORK_DIR}/\${DRIVER_ARCHIVE} \${DRIVER_VERSION}
+tar -C \${ARTIFACT_DIR} -cvj \$(basename -a \${ARTIFACT_DIR}/*.so.*) > libraries-\${DRIVER_VERSION}.tar.bz2
+tar -C \${ARTIFACT_DIR} -cvj \${TOOLS} > tools-\${DRIVER_VERSION}.tar.bz2
+
+if [ ! -d \${NVIDIA_DIR} ]
+then
+  mkdir -p \${NVIDIA_DIR}
+fi
+if [ ! -d \${NVIDIA_BIN_DIR} ]
+then
+  mkdir -p \${NVIDIA_BIN_DIR}
+  cp ./tools-\${DRIVER_VERSION}.tar.bz2 \${NVIDIA_BIN_DIR}
+  pushd \${NVIDIA_BIN_DIR}
+  tar -xjf ./tools-\${DRIVER_VERSION}.tar.bz2
+  rm -rf ./tools-\${DRIVER_VERSION}.tar.bz2
+  popd
+fi
+if [ ! -d \${NVIDIA_LIB_DIR} ]
+then
+  mkdir -p \${NVIDIA_LIB_DIR}
+  cp ./libraries-\${DRIVER_VERSION}.tar.bz2 \${NVIDIA_LIB_DIR}
+  pushd \${NVIDIA_LIB_DIR}
+
+  for LIBRARY_NAME in libcuda libGLESv1_CM \\
+    libGL libEGL \\
+    libnvidia-cfg libnvidia-encode libnvidia-fbc \\
+    libnvidia-ifr libnvidia-ml libnvidia-opencl \\
+    libnvcuvid libvdpau
+  do
+    ln -sf \${LIBRARY_NAME}.so.${DRIVER_VERSION} \${LIBRARY_NAME}.so.1
+    ln -sf \${LIBRARY_NAME}.so.1 \${LIBRARY_NAME}.so
+  done
+  
+  ln -sf libOpenCL.so.1.0.0 libOpenCL.so.1
+  ln -sf libOpenCL.so.1 libOpenCL.so
+  
+  ln -sf libGLESv2.so.\${DRIVER_VERSION} libGLESv2.so.2
+  ln -sf libGLESv2.so.2 libGLESv2.so
+  
+  ln -sf libvdpau_nvidia.so.\${DRIVER_VERSION} libvdpau_nvidia.so
+  ln -sf libvdpau_trace.so.\${DRIVER_VERSION} libvdpau_trace.so
+
+  tar -xjf ./libraries-\${DRIVER_VERSION}.tar.bz2
+  rm -rf ./libraries-\${DRIVER_VERSION}.tar.bz2
+  popd
+fi
+insmod \${WORK_DIR}/\${DRIVER_ARCHIVE}/kernel/uvm/nvidia-uvm.ko
+
+# Count the number of NVIDIA controllers found.
+NVDEVS=\`lspci | grep -i NVIDIA\`
+N3D=\`echo "\$NVDEVS" | grep "3D controller" | wc -l\`
+NVGA=\`echo "\$NVDEVS" | grep "VGA compatible controller" | wc -l\`
+N=\`expr \$N3D + \$NVGA - 1\`
+
+for i in \`seq 0 \$N\`; do
+        mknod -m 666 /dev/nvidia\$i c 195 \$i
+done
+
+mknod -m 666 /dev/nvidiactl c 195 255
+
+# Find out the major device number used by the nvidia-uvm driver
+D=\`grep nvidia-uvm /proc/devices | awk '{print \$1}'\`
+mknod -m 666 /dev/nvidia-uvm c \$D 0
+EOF
+
+  echo "Done"
+
+}
+
+
+

--- a/scripts/centos.sh
+++ b/scripts/centos.sh
@@ -310,7 +310,7 @@ mknod_nvidia_dev
 
 EOF
   echo "Done"
-  printf "Downding CentOS GPU drivers ...\n"
+  printf "Downloading CentOS GPU drivers ...\n"
   [ ! -d $BSROOT/html/static/CentOS7/gpu_drivers ] && mkdir  -p $BSROOT/html/static/CentOS7/gpu_drivers
 
   DRIVER_VERSION=${cluster_desc_gpu_drivers_version}


### PR DESCRIPTION
Fix #395 

在scripts/centos.sh中增加了一个函数download_centos_gpu_drivers()：
1.  下载指定版本号(scripts/centos.sh 183行)的nvidia gpu驱动到bsroot/html/static/CentOS7/gpu_drivers中
2. .创建一个驱动的安装脚本，保存到bsroot/html/static/CentOS7/gpu_drivers/build_centos_gpu_drivers.sh
集群安装驱动时，将bsroot/html/static/CentOS7/gpu_drivers目录（包含驱动和安装脚本）拷贝或http下载到集群节点上，cd gpu_drivers; sh build_centos_gpu_drivers.sh 完成安装