### PR TITLE
fix 441: ceph-mon.service and ceph-osd.service  dependent on docker.service

### DIFF
--- a/cloud-config-server/template/cloud-config.template
+++ b/cloud-config-server/template/cloud-config.template
@@ -373,6 +373,8 @@ coreos:
             Description=Install ceph mon services
             Requires=etcd2.service
             After=etcd2.service
+            Requires=docker.service
+            After=docker.service
             Requires=network.target
             After=network.target
 
@@ -393,6 +395,8 @@ coreos:
             Description=Install ceph osd service
             Requires=etcd2.service
             After=etcd2.service
+            Requires=docker.service
+            After=docker.service
             Requires=network.target
             After=network.target
 
@@ -619,6 +623,8 @@ ssh_authorized_keys:
       Description=Install ceph mon services
       Requires=etcd.service
       After=etcd.service
+      Requires=docker.service
+      After=docker.service
       Requires=network.target
       After=network.target
 
@@ -643,6 +649,8 @@ ssh_authorized_keys:
       Description=Install ceph osd service
       Requires=etcd.service
       After=etcd.service
+      Requires=docker.service
+      After=docker.service
       Requires=network.target
       After=network.target
 


### PR DESCRIPTION
Fix #441 
在cloud-config.template 文件中，ceph-mon.service 和 ceph-osd.service 的地方，增加依赖关系： docker.service ，解决安装 ceph 的时候，docker.service 还没有启动起来，导致 ceph 安装失败的问题。