### PR TITLE
Reserve TLS

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -251,7 +251,7 @@ generate_tls_assets() {
 
         printf "Generating CA TLS assets ... "
         openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
-        openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=kube-ca"  > /dev/null 2>&1
+        openssl req -x509 -new -nodes -key ca-key.pem -days 3650 -out ca.pem -subj "/CN=kube-ca"  > /dev/null 2>&1
         echo "Done"
 
         printf "Generating bootstrapper TLS assets ... "

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -257,7 +257,7 @@ generate_tls_assets() {
         printf "Generating bootstrapper TLS assets ... "
         openssl genrsa -out bootstrapper.key 2048 > /dev/null 2>&1
         openssl req -new -key bootstrapper.key -out bootstrapper.csr -subj "/CN=bootstrapper" > /dev/null 2>&1
-        openssl x509 -req -in bootstrapper.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out bootstrapper.crt -days 365 > /dev/null 2>&1
+        openssl x509 -req -in bootstrapper.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out bootstrapper.crt -days 3650 > /dev/null 2>&1
         echo "Done"
 
     fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -241,18 +241,26 @@ download_k8s_images() {
 generate_tls_assets() {
     mkdir -p $BSROOT/tls
     cd $BSROOT/tls
-    rm -rf $BSROOT/tls/*
 
-    printf "Generating CA TLS assets ... "
-    openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1 || { echo "Failed"; exit 1; }
-    openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=kube-ca"  > /dev/null 2>&1 || { echo "Failed"; exit 1; }
-    echo "Done"
+    if [[ -f ca.pem ]] && [[ -f ca-key.pem ]] && [[ -f bootstrapper.key ]] \
+        && [[ -f bootstrapper.csr ]] && [[ -f bootstrapper.crt ]]; then
 
-    printf "Generating bootstrapper TLS assets ... "
-    openssl genrsa -out bootstrapper.key 2048 > /dev/null 2>&1 || { echo "Failed"; exit 1; }
-    openssl req -new -key bootstrapper.key -out bootstrapper.csr -subj "/CN=bootstrapper" > /dev/null 2>&1 || { echo "Failed"; exit 1; }
-    openssl x509 -req -in bootstrapper.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out bootstrapper.crt -days 365 > /dev/null 2>&1 || { echo "Failed"; exit 1; }
-    echo "Done"
+        echo "Use exist CA TLS assets"
+
+    else
+
+        printf "Generating CA TLS assets ... "
+        openssl genrsa -out ca-key.pem 2048 > /dev/null 2>&1
+        openssl req -x509 -new -nodes -key ca-key.pem -days 10000 -out ca.pem -subj "/CN=kube-ca"  > /dev/null 2>&1
+        echo "Done"
+
+        printf "Generating bootstrapper TLS assets ... "
+        openssl genrsa -out bootstrapper.key 2048 > /dev/null 2>&1
+        openssl req -new -key bootstrapper.key -out bootstrapper.csr -subj "/CN=bootstrapper" > /dev/null 2>&1
+        openssl x509 -req -in bootstrapper.csr -CA ca.pem -CAkey ca-key.pem -CAcreateserial -out bootstrapper.crt -days 365 > /dev/null 2>&1
+        echo "Done"
+
+    fi
 }
 
 prepare_setup_kubectl() {


### PR DESCRIPTION
主要改动两点：
1. 把证书的默认有效期从 365 天改为 3650 天
2. 把每次运行 bsroot.sh 重新生成证书的逻辑改为，如果证书文件不存在就重新生成，历史生成证书已经存在就使用目前现有的证书，主要是为了解决：https://github.com/k8sp/sextant/issues/491#issuecomment-277587784 的第一种做法