### PR TITLE
Fix pull docker images

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -232,7 +232,7 @@ download_k8s_images() {
         local DOCKER_TAR_FILE=$BSROOT/`echo $DOCKER_IMAGE.tar | sed "s/:/_/g" |awk -F'/' '{print $2}'`
         if [[ ! -f $DOCKER_TAR_FILE ]]; then
             printf "Exporting $DOCKER_TAR_FILE ... "
-            docker save $DOCKER_IMAGE > $DOCKER_TAR_FILE.progress
+            docker save $DOCKER_DOMAIN_IMAGE_URL > $DOCKER_TAR_FILE.progress
             mv $DOCKER_TAR_FILE.progress $DOCKER_TAR_FILE
             echo "Done"
         fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -221,16 +221,18 @@ download_k8s_images() {
         # NOTE: if we updated remote image but didn't update its tag,
         # the following lines wouldn't pull because there is a local
         # image with the same tag.
-        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_IMAGE > /dev/null; then
+        DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
+        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
             printf "Pulling image ${DOCKER_IMAGE} ... "
-            docker pull $DOCKER_IMAGE > /dev/null 2>&1 || { echo "Failed"; exit 1; }
+            docker pull $DOCKER_IMAGE > /dev/null 2>&1
+            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
             echo "Done"
         fi
 
         local DOCKER_TAR_FILE=$BSROOT/`echo $DOCKER_IMAGE.tar | sed "s/:/_/g" |awk -F'/' '{print $2}'`
         if [[ ! -f $DOCKER_TAR_FILE ]]; then
             printf "Exporting $DOCKER_TAR_FILE ... "
-            docker save $DOCKER_IMAGE > $DOCKER_TAR_FILE.progress || { echo "Failed"; exit 1; }
+            docker save $DOCKER_IMAGE > $DOCKER_TAR_FILE.progress
             mv $DOCKER_TAR_FILE.progress $DOCKER_TAR_FILE
             echo "Done"
         fi

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -69,8 +69,9 @@ load_yaml $BSROOT/config/cluster-desc.yml cluster_desc_
 
 for DOCKER_IMAGE in $(set | grep '^cluster_desc_images_' | grep -o '".*"' | sed 's/"//g'); do
   DOCKER_TAR_FILE=$BSROOT/$(echo ${DOCKER_IMAGE}.tar | sed "s/:/_/g" |awk -F'/' '{print $2}')
+  printf "docker load & push $LOCAL_DOCKER_URL ... "
   LOCAL_DOCKER_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
-  docker load < $DOCKER_TAR_FILE
-  docker tag $DOCKER_IMAGE $LOCAL_DOCKER_URL
-  docker push $LOCAL_DOCKER_URL
+  docker load < $DOCKER_TAR_FILE >/dev/null 2>&1
+  docker push $LOCAL_DOCKER_URL >/dev/null 2>&1
+  echo "Done."
 done

--- a/start_bootstrapper_container.sh
+++ b/start_bootstrapper_container.sh
@@ -39,17 +39,6 @@ if ! grep -q "127.0.0.1 bootstrapper" /etc/hosts
   then echo "127.0.0.1 bootstrapper" >> /etc/hosts
 fi
 
-ntp_set=$(grep '^set_ntp' $BSROOT/config/cluster-desc.yml|cut -d : -f2)
-if [[ $ntp_set == " y" ]]; then
-docker load < $BSROOT/docker-ntp-server.tar > /dev/null 2>&1 || { echo "Docker can not load ntpserver.tar!"; exit 1; }
-docker rm -f ntpserver > /dev/null 2>&1
-docker run -d \
-       --name ntpserver \
-       --net=host \
-       --privileged \
-       redaphid/docker-ntp-server || { echo "Failed"; exit -1; }
-fi
-
 docker rm -f bootstrapper > /dev/null 2>&1
 docker rmi bootstrapper:latest > /dev/null 2>&1
 docker load < $BSROOT/bootstrapper.tar > /dev/null 2>&1 || { echo "Docker can not load bootstrapper.tar!"; exit 1; }
@@ -75,3 +64,14 @@ for DOCKER_IMAGE in $(set | grep '^cluster_desc_images_' | grep -o '".*"' | sed 
   docker push $LOCAL_DOCKER_URL >/dev/null 2>&1
   echo "Done."
 done
+
+if [[ $cluster_desc_set_ntp == " y" ]]; then
+docker rm -f ntpserver > /dev/null 2>&1
+NTP_DOCKER_IMAGE=$cluster_desc_dockerdomain:5000/${cluster_desc_images_ntp}
+docker run -d \
+       --name ntpserver \
+       --net=host \
+       --privileged \
+       $NTP_DOCKER_IMAGE || { echo "Failed"; exit -1; }
+fi
+


### PR DESCRIPTION
目前保存 docker image 的逻辑是：
1. grep docker image name without bootstrapper domain
2. 不存在则执行pull，  进而 save 无 bootstrapper domain 的镜像到 tar 包
3. 在 start_bootstrapper_container.sh 中从 tar 包中 load  镜像，然后 tag with domain , 之后 push 带 domain 的镜像

存在问题：
1. 当执行 bsroot.sh 的机器中存在带 domain 的镜像，而不存在不带 bootstrapper 的同名镜像时
2. 第一步的 grep 时为 True，则不执行 pull ，而直接 save 无 bootstrapper domain 的镜像到 tar 包，则会报错

解决方案：
1. grep docker image name with bootstrapper domain
2. 不存在则执行pull， 然后 tag with domain ,  进而 save 带 bootstrapper domain 的镜像到 tar 包
3. 在 start_bootstrapper_container.sh 中从 tar 包中 load  镜像，之后 push 带 domain 的镜像