### PR TITLE
fix #515, #517

### DIFF
--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -207,7 +207,7 @@ download_k8s_images() {
     # printf "Downloading kubelet ${hyperkube_version} ... "
     # wget --quiet -c -N -O $BSROOT/html/static/kubelet https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/linux/amd64/kubelet
     printf "Downloading kubelet ... "
-    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet || { echo "Failed"; exit 1; }
+    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet
     echo "Done"
     
     # setup-network-environment will fetch the default system IP infomation
@@ -221,23 +221,16 @@ download_k8s_images() {
         # NOTE: if we updated remote image but didn't update its tag,
         # the following lines wouldn't pull because there is a local
         # image with the same tag.
-        DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
-#        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
-#            printf "Pulling image ${DOCKER_IMAGE} ... "
-#            docker pull $DOCKER_IMAGE > /dev/null 2>&1
-#            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
-#            echo "Done"
-#        fi
-
+        local DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
         local DOCKER_TAR_FILE=$BSROOT/`echo $DOCKER_IMAGE.tar | sed "s/:/_/g" |awk -F'/' '{print $2}'`
         if [[ ! -f $DOCKER_TAR_FILE ]]; then
             if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
                 printf "Pulling image ${DOCKER_IMAGE} ... "
                 docker pull $DOCKER_IMAGE > /dev/null 2>&1
-                docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
                 echo "Done"
             fi
             printf "Exporting $DOCKER_TAR_FILE ... "
+            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
             docker save $DOCKER_DOMAIN_IMAGE_URL > $DOCKER_TAR_FILE.progress
             mv $DOCKER_TAR_FILE.progress $DOCKER_TAR_FILE
             echo "Done"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -207,7 +207,7 @@ download_k8s_images() {
     # printf "Downloading kubelet ${hyperkube_version} ... "
     # wget --quiet -c -N -O $BSROOT/html/static/kubelet https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/linux/amd64/kubelet
     printf "Downloading kubelet ... "
-    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet || { echo "Failed"; exit 1; }
+    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet
     echo "Done"
     
     # setup-network-environment will fetch the default system IP infomation
@@ -221,26 +221,21 @@ download_k8s_images() {
         # NOTE: if we updated remote image but didn't update its tag,
         # the following lines wouldn't pull because there is a local
         # image with the same tag.
-        DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
-#        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
-#            printf "Pulling image ${DOCKER_IMAGE} ... "
-#            docker pull $DOCKER_IMAGE > /dev/null 2>&1
-#            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
-#            echo "Done"
-#        fi
-
+        local DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
         local DOCKER_TAR_FILE=$BSROOT/`echo $DOCKER_IMAGE.tar | sed "s/:/_/g" |awk -F'/' '{print $2}'`
         if [[ ! -f $DOCKER_TAR_FILE ]]; then
             if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
                 printf "Pulling image ${DOCKER_IMAGE} ... "
                 docker pull $DOCKER_IMAGE > /dev/null 2>&1
-                docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
                 echo "Done"
             fi
             printf "Exporting $DOCKER_TAR_FILE ... "
+            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
             docker save $DOCKER_DOMAIN_IMAGE_URL > $DOCKER_TAR_FILE.progress
             mv $DOCKER_TAR_FILE.progress $DOCKER_TAR_FILE
             echo "Done"
+        else 
+            echo “Use existing $DOCKER_TAR_FILE” 
         fi
     done
 }

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -91,7 +91,7 @@ check_cluster_desc_file() {
     echo "Done"
 
     printf "Checking cluster description file ..."
-    docker run -it \
+    docker run --rm -it \
         --volume $GOPATH:/go \
         --volume $BSROOT:/bsroot \
         golang:wheezy \
@@ -207,9 +207,9 @@ download_k8s_images() {
     # printf "Downloading kubelet ${hyperkube_version} ... "
     # wget --quiet -c -N -O $BSROOT/html/static/kubelet https://storage.googleapis.com/kubernetes-release/release/$hyperkube_version/bin/linux/amd64/kubelet
     printf "Downloading kubelet ... "
-    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet
+    wget --quiet -c -N -O $BSROOT/html/static/kubelet https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubelet || { echo "Failed"; exit 1; }
     echo "Done"
-
+    
     # setup-network-environment will fetch the default system IP infomation
     # when using cloud-config file to initiate a kubernetes cluster node
     printf "Downloading setup-network-environment file ... "
@@ -222,15 +222,21 @@ download_k8s_images() {
         # the following lines wouldn't pull because there is a local
         # image with the same tag.
         DOCKER_DOMAIN_IMAGE_URL=$cluster_desc_dockerdomain:5000/${DOCKER_IMAGE}
-        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
-            printf "Pulling image ${DOCKER_IMAGE} ... "
-            docker pull $DOCKER_IMAGE > /dev/null 2>&1
-            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
-            echo "Done"
-        fi
+#        if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
+#            printf "Pulling image ${DOCKER_IMAGE} ... "
+#            docker pull $DOCKER_IMAGE > /dev/null 2>&1
+#            docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
+#            echo "Done"
+#        fi
 
         local DOCKER_TAR_FILE=$BSROOT/`echo $DOCKER_IMAGE.tar | sed "s/:/_/g" |awk -F'/' '{print $2}'`
         if [[ ! -f $DOCKER_TAR_FILE ]]; then
+            if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep $DOCKER_DOMAIN_IMAGE_URL > /dev/null; then
+                printf "Pulling image ${DOCKER_IMAGE} ... "
+                docker pull $DOCKER_IMAGE > /dev/null 2>&1
+                docker tag $DOCKER_IMAGE $DOCKER_DOMAIN_IMAGE_URL
+                echo "Done"
+            fi
             printf "Exporting $DOCKER_TAR_FILE ... "
             docker save $DOCKER_DOMAIN_IMAGE_URL > $DOCKER_TAR_FILE.progress
             mv $DOCKER_TAR_FILE.progress $DOCKER_TAR_FILE
@@ -266,10 +272,16 @@ generate_tls_assets() {
 }
 
 prepare_setup_kubectl() {
-  printf "Preparing setup kubectl ... "
-  sed -i -e "s/<KUBE_MASTER_HOSTNAME>/$KUBE_MASTER_HOSTNAME/g" $SEXTANT_DIR/setup-kubectl.bash
-  chmod +x $BSROOT/setup_kubectl.bash
-  echo "Done"
+    printf "Downloading kubectl ... "
+    wget --quiet -c -N -O $BSROOT/html/static/kubectl https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubectl || { echo "Failed"; exit 1; }
+    echo "Done"
+
+    printf "Preparing setup kubectl ... "
+    sed -i -e "s/<KUBE_MASTER_HOSTNAME>/$KUBE_MASTER_HOSTNAME/g" $SEXTANT_DIR/setup-kubectl.bash
+    sed -i -e "s/<BS_IP>/$BS_IP/g" $SEXTANT_DIR/setup-kubectl.bash
+    cp $SEXTANT_DIR/setup-kubectl.bash $BSROOT/setup_kubectl.bash
+    chmod +x $BSROOT/setup_kubectl.bash
+    echo "Done"
 }
 
 generate_addons_config() {

--- a/setup-kubectl.bash
+++ b/setup-kubectl.bash
@@ -6,7 +6,7 @@ setup_kubectl() {
   # Download kubectl binary
   wget --quiet -c -O "./kubectl" http://$BS_IP/static/kubectl
   chmod +x ./kubectl
-  if [[ ! -d $BSROOT ]]; then
+  if [[ ! -d ~/bin ]]; then
     mkdir ~/bin
   fi
   cp ./kubectl ~/bin/

--- a/setup-kubectl.bash
+++ b/setup-kubectl.bash
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 
 KUBE_MASTER_HOSTNAME=<KUBE_MASTER_HOSTNAME>
-
+BS_IP=<BS_IP>
 setup_kubectl() {
   # Download kubectl binary
-  wget --quiet -c -O "./kubectl" https://dl.dropboxusercontent.com/u/27178121/kubelet.v1.6.0/kubectl
+  wget --quiet -c -O "./kubectl" http://$BS_IP/static/kubectl
   chmod +x ./kubectl
+  if [[ ! -d $BSROOT ]]; then
+    mkdir ~/bin
+  fi
+  cp ./kubectl ~/bin/
   # Configure kubectl
   echo $KUBE_MASTER_HOSTNAME
-  ./kubectl config set-cluster default-cluster --server=http://$KUBE_MASTER_HOSTNAME:8080
-  ./kubectl config set-context default-system --cluster=default-cluster
-  ./kubectl config use-context default-system
+  kubectl config set-cluster default-cluster --server=http://$KUBE_MASTER_HOSTNAME:8080
+  kubectl config set-context default-system --cluster=default-cluster
+  kubectl config use-context default-system
 }
 
 setup_kubectl


### PR DESCRIPTION
Fixes #515 #517 
主要解决了下面的问题：
1. 执行 bsroot.sh 的时候，并没有把修改后的 setup-kubectl.bash 复制到 bsroot 目录中
2. setup-kubectl.bash 脚本需要到外网去下载 kubectl，这个逻辑改为：在 bsroot.sh 中下载 kubectl ，其他需要使用 kubectl 的机器直接到 Bootstrapper 上下载。
3. setup-kubectl.bash 中，直接将  Bootstrapper 上下载下来的 kubectl 复制到 ~/bin 目录下，这样就不需要再每次执行 kubectl 的时候，指定路径了。
4. 在处理 docker image 的时候，[common.sh#L233](https://github.com/k8sp/sextant/blob/develop/scripts/common.sh#L233) 
原来的逻辑是：先看看本地 docker image 里面有没有现成的 ，如果没有，执行 docker pull，然后 docker save，docker tag 等操作。
现在改成：先看看有没有相应的 tar 包，如果没有，再判断 本地的 docker image 里面有没有。这个主要是考虑到，我们有可能从别的地方将 tar 包复制过来了，但是我们的脚本还需要去执行 docker pull，浪费时间。