### PR TITLE
dnsmasq 将 DNS query 的日志打印出来，占用太多空间。

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # start dnsmasq
 mkdir -p /bsroot/dnsmasq
-dnsmasq --log-facility=- -q --conf-file=/bsroot/config/dnsmasq.conf \
+dnsmasq --log-facility=-  --conf-file=/bsroot/config/dnsmasq.conf \
   --dhcp-leasefile=/bsroot/dnsmasq/dnsmasq.leases
 
 # start cloud-config-server


### PR DESCRIPTION
Fix #519 
将 dnsmasq 的 dns query 日志关闭