### PR TITLE
remove necessary space which blocks dnamasq

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ if [[ $# != 1 ]]; then
     exit 1
 fi
 
-if [[ $1 == " y" ]]; then
+if [[ $1 == "y" ]]; then
     # start dnsmasq
     mkdir -p /bsroot/dnsmasq
     dnsmasq --log-facility=-  --conf-file=/bsroot/config/dnsmasq.conf \


### PR DESCRIPTION
fix #578 
just found the reason why dnsmaq is not started even with paramter "y", in entrypoint.sh, the judgment line for starting dnsmasq is trying to compare if $1 == " y" instead of "y"
not sure why there is a space there, is this for come compatibility?
anyway, it works in my case if I removed the space, let me know if this space is necessary.
