### PR TITLE
added dynamic name service

### DIFF
--- a/docker/dhcp.sh
+++ b/docker/dhcp.sh
@@ -18,11 +18,11 @@ then
     rm -f $filepath
   fi
   cat > $filepath <<EOF
-$ip $hostname
+$ip $filename
 EOF
-  if [[ $filename != $hostname ]]
+  if [[ $hostname != "" && $filename != $hostname ]]
   then
-    echo "$ip $filename" >> $filepath
+    echo "$ip $hostname" >> $filepath
   fi
 fi
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,7 +5,7 @@ if [[ $# != 1 ]]; then
     exit 1
 fi
 
-if [[ $1 == " y" ]]; then
+if [[ $1 == "y" ]]; then
     # start dnsmasq
     mkdir -p /bsroot/dnsmasq
     dnsmasq --log-facility=-  --conf-file=/bsroot/config/dnsmasq.conf \

--- a/golang/addons/template/dnsmasq.conf.template
+++ b/golang/addons/template/dnsmasq.conf.template
@@ -29,4 +29,4 @@ pxe-service=x86PC, "Install CoreOS from network server", pxelinux
 enable-tftp
 tftp-root=/bsroot/tftpboot
 dhcp-script=/dhcp.sh
-hostsdir=/bsroot/hosts.d
+hostsdir=/bsroot/dnsmasq/hosts.d


### PR DESCRIPTION
it works by listening to dnsmasq's dhcp event, and add/remove newly added/removed ip and hostname info into the folder of hosts.d, which dnsmasq is monitoring. 
host record files are named after its mac address.
with this change, if the name servers option in cluster.yaml is pointing to bootstrapper's ip address, cluster machines can talk to each other by hostnames.
TODOs: 
1. bootstrapper is not able to resolve cluster machines hostname within itself by default, has to manually set name server to itself. i.e. in a command line window in bootstrapper, it will say `Unknown host` if you try "ping node1", since bootstrapper is not using itself as the name server. But this line of command will work if you try within a cluster machine.

2. HA and performance issue for large scaled cluster bootstrapping. see disscussions [here](https://github.com/k8sp/sextant/issues/577#issuecomment-333296384) 
Currently this feature is only for experimental or small cluster bootstrapping. 
fix #580
